### PR TITLE
Fixed Current Market Value and Agent Name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .vscode
 .env
 .scrapy
+.spyproject

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -80,9 +80,9 @@ class PlayersSpider(BaseSpider):
     # The agent name can either be inside the anchor tag, title of the anchor tag or 
     attributes['player_agent'] = {
       'href': response.xpath("//span[text()='Player agent:']/following::span[1]/a/@href").get(),
-      'name': response.xpath("//span[text()='Player agent:']/following::span[1]/a/span[@class='cp']/@title").get() or
-              response.xpath("//span[text()='Player agent:']/following::span[1]/span[@class='cp']/text()").get() or
-              response.xpath("//span[text()='Player agent:']/following::span[1]/span/text()").get()
+      'name': response.xpath("//span[text()='Player agent:']/following::span[1]/a/span[@class='cp']/@title").get() or  # Case 1: agent name in title attribute
+              response.xpath("//span[text()='Player agent:']/following::span[1]/a/text()").get() or  # Case 2: agent name in <a> text
+              response.xpath("//span[text()='Player agent:']/following::span[1]/span/text()").get()  # Case 3: agent name in <span> text without <a>
     }
     attributes['image_url'] = response.xpath("//img[@class='data-header__profile-image']/@src").get()
     attributes['current_club'] = {

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -76,9 +76,13 @@ class PlayersSpider(BaseSpider):
     attributes['height'] = response.xpath("//span[text()='Height:']/following::span[1]/text()").get()
     attributes['citizenship'] = response.xpath("//span[text()='Citizenship:']/following::span[1]/img/@title").get()
     attributes['position'] = self.safe_strip(response.xpath("//span[text()='Position:']/following::span[1]/text()").get())
+    
+    # The agent name can either be inside the anchor tag, title of the anchor tag or 
     attributes['player_agent'] = {
       'href': response.xpath("//span[text()='Player agent:']/following::span[1]/a/@href").get(),
-      'name': response.xpath("//span[text()='Player agent:']/following::span[1]/a/text()").get()
+      'name': response.xpath("//span[text()='Player agent:']/following::span[1]/a/text()").get() or
+              response.xpath("//span[text()='Player agent:']/following::span[1]/span[@class='cp']/@title").get() or
+              response.xpath("//span[text()='Player agent:']/following::span[1]/span[@class='cp']/text()").get()
     }
     attributes['image_url'] = response.xpath("//img[@class='data-header__profile-image']/@src").get()
     attributes['current_club'] = {

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -91,7 +91,7 @@ class PlayersSpider(BaseSpider):
     attributes['outfitter'] = response.xpath("//span[text()='Outfitter:']/following::span[1]/text()").get()
 
     # current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
-    current_market_value_text = response.xpath("//div[@class='current-value svelte-gfmgwx']/a[1]/text()").get()
+    current_market_value_text = self.safe_strip(response.xpath("//div[@class='current-and-max svelte-gfmgwx']//div[@class='current-value svelte-gfmgwx']/a[1]/text()").get())
     # current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
     if current_market_value_text: # sometimes the actual value is in the same level (https://www.transfermarkt.co.uk/femi-seriki/profil/spieler/638649)
         value_text = current_market_value_text.replace("€", "").strip()

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -91,9 +91,8 @@ class PlayersSpider(BaseSpider):
     attributes['outfitter'] = response.xpath("//span[text()='Outfitter:']/following::span[1]/text()").get()
 
     # current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
-    current_market_value_text = self.safe_strip(response.xpath("//div[@class='current-value svelte-gfmgwx']/a[1]/text()").get())
-    current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
-    print(current_market_value_text)
+    current_market_value_text = response.xpath("//div[@class='current-value svelte-gfmgwx']/a[1]/text() | //div[@class='current-value svelte-gfmgwx']/text()").get()
+    # current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
     if current_market_value_text: # sometimes the actual value is in the same level (https://www.transfermarkt.co.uk/femi-seriki/profil/spieler/638649)
         value_text = current_market_value_text.replace("€", "").strip()
         if value_text.endswith("k"):
@@ -104,7 +103,7 @@ class PlayersSpider(BaseSpider):
             market_value = float(value_text)  # Fallback in case no suffix is present
         attributes['current_market_value'] = market_value
     else: # sometimes is one level down (https://www.transfermarkt.co.uk/rhys-norrington-davies/profil/spieler/543164)
-      attributes['current_market_value'] = current_market_value_link
+      attributes['current_market_value'] = None
     attributes['highest_market_value'] = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__max-value']/text()").get())
 
     social_media_value_node = response.xpath("//span[text()='Social-Media:']/following::span[1]")

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -59,6 +59,7 @@ class PlayersSpider(BaseSpider):
 
     # parse 'PLAYER DATA' section
 
+    print(response.text)
     attributes = {}
 
     name_element = response.xpath("//h1[@class='data-header__headline-wrapper']")
@@ -91,8 +92,6 @@ class PlayersSpider(BaseSpider):
     attributes['outfitter'] = response.xpath("//span[text()='Outfitter:']/following::span[1]/text()").get()
 
     # current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
-    print("****\n***")
-    print(response.xpath("//div[contains(@class, 'current-and-max')]//div[contains(@class, 'current-value')]").get())
     current_market_value_text = self.safe_strip(response.xpath("//div[@class='current-and-max svelte-gfmgwx']//div[@class='current-value svelte-gfmgwx']/a[1]/text()").get())
     # current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
     if current_market_value_text: # sometimes the actual value is in the same level (https://www.transfermarkt.co.uk/femi-seriki/profil/spieler/638649)

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -93,6 +93,7 @@ class PlayersSpider(BaseSpider):
     # current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
     current_market_value_text = self.safe_strip(response.xpath("//div[@class='current-value svelte-gfmgwx']/a[1]/text()").get())
     current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
+    print(current_market_value_text)
     if current_market_value_text: # sometimes the actual value is in the same level (https://www.transfermarkt.co.uk/femi-seriki/profil/spieler/638649)
         value_text = current_market_value_text.replace("€", "").strip()
         if value_text.endswith("k"):

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -91,7 +91,7 @@ class PlayersSpider(BaseSpider):
     attributes['outfitter'] = response.xpath("//span[text()='Outfitter:']/following::span[1]/text()").get()
 
     # current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
-    current_market_value_text = response.xpath("//div[@class='current-value svelte-gfmgwx']/a[1]/text() | //div[@class='current-value svelte-gfmgwx']/text()").get()
+    current_market_value_text = response.xpath("//div[@class='current-value svelte-gfmgwx']/text()").get()
     # current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
     if current_market_value_text: # sometimes the actual value is in the same level (https://www.transfermarkt.co.uk/femi-seriki/profil/spieler/638649)
         value_text = current_market_value_text.replace("€", "").strip()
@@ -102,7 +102,7 @@ class PlayersSpider(BaseSpider):
         else:
             market_value = float(value_text)  # Fallback in case no suffix is present
         attributes['current_market_value'] = market_value
-    else: # sometimes is one level down (https://www.transfermarkt.co.uk/rhys-norrington-davies/profil/spieler/543164)
+    else:
       attributes['current_market_value'] = None
     attributes['highest_market_value'] = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__max-value']/text()").get())
 

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -80,9 +80,9 @@ class PlayersSpider(BaseSpider):
     # The agent name can either be inside the anchor tag, title of the anchor tag or 
     attributes['player_agent'] = {
       'href': response.xpath("//span[text()='Player agent:']/following::span[1]/a/@href").get(),
-      'name': response.xpath("//span[text()='Player agent:']/following::span[1]/a/text()").get() or
-              response.xpath("//span[text()='Player agent:']/following::span[1]/span[@class='cp']/@title").get() or
-              response.xpath("//span[text()='Player agent:']/following::span[1]/span[@class='cp']/text()").get()
+      'name': response.xpath("//span[text()='Player agent:']/following::span[1]/a/span[@class='cp']/@title").get() or
+              response.xpath("//span[text()='Player agent:']/following::span[1]/span[@class='cp']/text()").get() or
+              response.xpath("//span[text()='Player agent:']/following::span[1]/span/text()").get()
     }
     attributes['image_url'] = response.xpath("//img[@class='data-header__profile-image']/@src").get()
     attributes['current_club'] = {

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -91,7 +91,7 @@ class PlayersSpider(BaseSpider):
     attributes['outfitter'] = response.xpath("//span[text()='Outfitter:']/following::span[1]/text()").get()
 
     # current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
-    current_market_value_text = response.xpath("//div[@class='current-value svelte-gfmgwx']/text()").get()
+    current_market_value_text = response.xpath("//div[@class='current-value svelte-gfmgwx']/a[1]/text()").get()
     # current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
     if current_market_value_text: # sometimes the actual value is in the same level (https://www.transfermarkt.co.uk/femi-seriki/profil/spieler/638649)
         value_text = current_market_value_text.replace("€", "").strip()

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -90,10 +90,18 @@ class PlayersSpider(BaseSpider):
     attributes['day_of_last_contract_extension'] = response.xpath("//span[text()='Date of last contract extension:']/following::span[1]/text()").get()
     attributes['outfitter'] = response.xpath("//span[text()='Outfitter:']/following::span[1]/text()").get()
 
-    current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
+    # current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
+    current_market_value_text = self.safe_strip(response.xpath("//div[@class='current-value svelte-gfmgwx']/a[1]/text()").get())
     current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
     if current_market_value_text: # sometimes the actual value is in the same level (https://www.transfermarkt.co.uk/femi-seriki/profil/spieler/638649)
-      attributes['current_market_value'] = current_market_value_text
+        value_text = current_market_value_text.replace("€", "").strip()
+        if value_text.endswith("k"):
+            market_value = float(value_text[:-1]) * 1_000
+        elif value_text.endswith("m"):
+            market_value = float(value_text[:-1]) * 1_000_000
+        else:
+            market_value = float(value_text)  # Fallback in case no suffix is present
+        attributes['current_market_value'] = market_value
     else: # sometimes is one level down (https://www.transfermarkt.co.uk/rhys-norrington-davies/profil/spieler/543164)
       attributes['current_market_value'] = current_market_value_link
     attributes['highest_market_value'] = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__max-value']/text()").get())

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -91,6 +91,8 @@ class PlayersSpider(BaseSpider):
     attributes['outfitter'] = response.xpath("//span[text()='Outfitter:']/following::span[1]/text()").get()
 
     # current_market_value_text = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/text()").get())
+    print("****\n***")
+    print(response.xpath("//div[contains(@class, 'current-and-max')]//div[contains(@class, 'current-value')]").get())
     current_market_value_text = self.safe_strip(response.xpath("//div[@class='current-and-max svelte-gfmgwx']//div[@class='current-value svelte-gfmgwx']/a[1]/text()").get())
     # current_market_value_link = self.safe_strip(response.xpath("//div[@class='tm-player-market-value-development__current-value']/a/text()").get())
     if current_market_value_text: # sometimes the actual value is in the same level (https://www.transfermarkt.co.uk/femi-seriki/profil/spieler/638649)


### PR DESCRIPTION
### Made changes to `tfmkt/spiders/players.py`:

**Player agent name:**
- Case 1: agent name in `title` attribute
- Case 2: agent name in `<a>` text
- Case 3: agent name in `<span>` text without `<a>`

**Current Market Value**
NOTE: Current Market value could not be fetched from the original placeholders and looks like they are loaded dynamically. This is a disadvantage of using Scrapy. Scrapy only captures the initial HTML response and not dynamically loaded elements.

Thankfully, the meta description contains the current market value. Fetched the market value in string format, stripped the euro symbol, converted to a numerical value (k -> 1000, m -> 1_000_000) and converted to a floating point.
