### PR TITLE
fix: include href attribute in player data output

### DIFF
--- a/tfmkt/spiders/players_from_file.py
+++ b/tfmkt/spiders/players_from_file.py
@@ -26,7 +26,7 @@ class PlayersFromFileSpider(BaseSpider):
 
     # parse 'PLAYER DATA' section
 
-    attributes = {"type": "player"}
+    attributes = {"type": "player", "href": parent.get('href')}
     base = parent  # In this spider, parent contains the base data including href
 
     name_element = response.xpath("//h1[@class='data-header__headline-wrapper']")


### PR DESCRIPTION
## Summary
- Fixed missing href attribute in players_from_file spider output
- Ensures player Transfermarkt URL is included in scraped data

## Changes
- Added `href` attribute to the attributes dictionary in `players_from_file.py`
- Fixed trailing newline formatting

## Test plan
- [ ] Run the players_from_file spider with a sample input file
- [ ] Verify that the output includes the href field for each player
- [ ] Confirm no other functionality is affected