### PR TITLE
feat: add national team career scraping to players_from_file spider and Italian youth leagues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,31 @@ samples/
 └── html/                      # Sample HTML files for testing XPath selectors
 ```
 
+## Spider Synchronization
+
+**IMPORTANT:** The `players.py` and `players_from_file.py` spiders should be kept synchronized with the following understanding:
+
+- **players.py** - Scrapes players from club pages (requires club entrypoint)
+  - Has `parse()` method to collect player URLs from club roster
+  - Has `parse_details()` method to extract player data
+
+- **players_from_file.py** - Scrapes players directly from URLs (file/stdin input)
+  - Has only `parse()` method which is equivalent to `parse_details()` in players.py
+
+**Synchronization Rule:**
+- All data extraction logic (XPath selectors, helper methods, parsing logic) should be **identical** between:
+  - `players.py::parse_details()` and subsequent methods
+  - `players_from_file.py::parse()` and subsequent methods
+- When adding features to one spider, port them to the other unless explicitly noted otherwise
+- Both spiders should produce the same output structure for the same player URL
+
+**Current synchronized features:**
+- Player profile data extraction
+- National team career scraping (totals, competitions, matches)
+- Market value parsing
+- Status detection (active/retired/deceased)
+- Error handling with graceful degradation
+
 ## Spider Input/Output
 
 Spiders expect input via **stdin** or a **parents file** (JSON lines format):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,245 @@
+# Transfermarkt Scraper - Development Guide
+
+## Project Overview
+
+A Scrapy-based web scraper for collecting football data from Transfermarkt. The scraper follows a hierarchical structure:
+
+```
+Confederations → Competitions → Clubs → Players → Appearances
+```
+
+## Environment Setup
+
+```bash
+# Python version required
+python3.9
+
+# Install dependencies
+poetry install
+
+# Run any command with poetry
+poetry run <command>
+```
+
+## Project Structure
+
+```
+tfmkt/
+├── spiders/
+│   ├── common.py              # BaseSpider class with shared utilities
+│   ├── common_comp_club.py    # Enhanced base with URL seasonization
+│   ├── players.py             # Player details + national career scraping
+│   ├── players_from_file.py   # Alternative player spider with file input
+│   ├── appearances.py         # Player appearance stats
+│   ├── games.py               # Match/game data
+│   └── ...
+├── settings.py                # Scrapy settings
+└── ...
+samples/
+└── html/                      # Sample HTML files for testing XPath selectors
+```
+
+## Spider Input/Output
+
+Spiders expect input via **stdin** or a **parents file** (JSON lines format):
+
+```bash
+# Via stdin
+echo '{"type": "club", "href": "/fc-barcelona/startseite/verein/131"}' | poetry run scrapy crawl players -o output.json
+
+# Via parents file
+poetry run scrapy crawl players -a parents=clubs.jsonl -o players.json
+
+# Compressed parents file
+poetry run scrapy crawl players -a parents=clubs.jsonl.gz -o players.json
+```
+
+## Key Code Patterns
+
+### BaseSpider (common.py)
+- `__init__(base_url, parents)` - Loads parent entities from stdin or file
+- `start_requests()` - Generates initial requests from entrypoints
+- `seasonize_entrypoin_href()` - Adds season parameters to URLs
+- `safe_strip(word)` - Null-safe string stripping
+
+### Request Chaining
+```python
+# Chain to next parse method with context
+yield response.follow(
+    url,
+    self.parse_next,
+    cb_kwargs={'base': base, 'attributes': attributes},
+    errback=self.errback_handler
+)
+```
+
+### XPath Tips for Transfermarkt
+- `colspan` in `<td>` doesn't affect XPath element indexing - `td[N]` counts actual elements
+- Tables often have hidden columns: `<td class="hide">`
+- Injury/unavailable rows have class `bg_rot_20`
+- Result links have class `ergebnis-link` with `greentext`/`redtext` spans
+
+## Testing
+
+### Test XPath Selectors with Sample HTML
+```python
+from scrapy.http import HtmlResponse, Request
+
+def create_mock_response(html_file, url):
+    with open(html_file, 'r', encoding='utf-8') as f:
+        body = f.read().encode('utf-8')
+    request = Request(url=url)
+    return HtmlResponse(url=url, body=body, request=request)
+
+# Use in tests
+response = create_mock_response('samples/html/yamal_national.html', 'https://...')
+result = response.xpath("//table[@class='items']//tfoot/tr/td[3]/text()").get()
+```
+
+### Run Spider Tests
+```bash
+# Scrapy's built-in contract tests
+poetry run scrapy check players
+
+# Test with local HTML (create test script)
+poetry run python test_script.py
+```
+
+### Sample HTML Files
+- `samples/html/yamal.html` - Player profile page
+- `samples/html/yamal_national.html` - National career page (extensive)
+- `samples/html/casado.html` - Player profile page
+- `samples/html/casado_national.html` - National career page (minimal)
+
+## National Career Feature (players.py)
+
+### URL Transformation
+```
+Profile:         /{player-slug}/profil/spieler/{player_id}
+National Career: /{player-slug}/nationalmannschaft/spieler/{player_id}
+Specific Team:   /{player-slug}/nationalmannschaft/spieler/{player_id}/verein_id/{team_id}
+```
+
+### Request Flow
+```
+parse_details()
+  └── parse_national_career() [gets dropdown + default team stats]
+        └── parse_national_team_stats() [for each additional team]
+              └── yield final player item
+```
+
+### Data Structure
+```python
+{
+  # ... existing player fields ...
+  "national_career": [
+    {
+      "national_team": {
+        "id": "3375",
+        "name": "Spain",
+        "href": "/spain/startseite/verein/3375"
+      },
+      "totals": {
+        "appearances": 23,
+        "goals": 6,
+        "assists": 12,
+        "yellow_cards": 3,
+        "second_yellow_cards": 0,
+        "red_cards": 0,
+        "minutes_played": 1651
+      },
+      "competitions": [
+        {
+          "name": "UEFA Nations League",
+          "href": "/...",
+          "icon_url": "https://...",
+          "appearances": 7,
+          "goals": 3,
+          ...
+        }
+      ],
+      "matches": [
+        {
+          "competition": "European Qualifiers",
+          "competition_href": "/...",
+          "matchday": "Group A",
+          "date": "08/09/23",
+          "venue": "A",
+          "team": "Spain",
+          "team_href": "/...",
+          "opponent": "Georgia",
+          "opponent_href": "/...",
+          "result": "1:7",
+          "result_type": "win",
+          "game_id": 3941392,
+          "game_href": "/spielbericht/index/spielbericht/3941392",
+          "position": "RW",
+          "position_full": "Right Winger",
+          "goals": 1,
+          "assists": 0,
+          "yellow_cards": 0,
+          "second_yellow_cards": 0,
+          "red_cards": 0,
+          "minutes_played": 46,
+          "unavailable": null  // or "muscular problems" for injuries
+        }
+      ]
+    },
+    // ... more teams (U19, U21, etc.)
+  ]
+}
+```
+
+### Key XPath Selectors (National Career Page)
+
+**National Teams Dropdown:**
+```xpath
+//select[@name='verein_id']/option  → @value=team_id, text()=team_name
+//select[@name='verein_id']/option[@selected]  → currently selected
+```
+
+**Compact Stats Table:**
+```xpath
+//table[@class='items']  → main table
+.//tfoot/tr/td[3]  → appearances (td[1] has colspan=2)
+.//tfoot/tr/td[4]  → goals
+.//tbody/tr  → competition rows
+```
+
+**Detailed Stats Table:**
+```xpath
+(//div[@class='responsive-table'])[2]//table/tbody  → matches table
+./tr[td[@colspan='20']]  → competition header rows
+./tr[@class='bg_rot_20']  → unavailable/injury rows
+./td[7]//a/@title  → opponent name
+./td[9]/a/text()  → position
+./td[15]/text()  → minutes played
+```
+
+## Common Issues
+
+### 403 Errors
+Transfermarkt blocks requests without proper headers. Solutions:
+1. Configure User-Agent in `settings.py`
+2. Use proxy rotation
+3. Add cookies from browser session
+
+### Poetry Environment Issues
+If poetry's venv is corrupted:
+```bash
+# Remove and reinstall poetry
+rm -rf ~/.local/share/pypoetry/venv
+curl -sSL https://install.python-poetry.org | python3.9 - --force
+
+# Reinstall project dependencies
+poetry install
+```
+
+## Debugging
+
+```python
+# In any spider method, uncomment to open interactive shell:
+from scrapy.shell import inspect_response
+inspect_response(response, self)
+exit(1)
+```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -452,7 +452,8 @@ scrapy crawl games -a parents=competitions.json -a season=2020 > games.json
 **Output Fields:**
 - `type`: "game"
 - `game_id`: Transfermarkt game ID
-- `href`: Game URL path
+- `href`: Game URL path (relative)
+- `seasoned_href`: Full absolute URL to the game page
 - `date_iso`: ISO format date (YYYY-MM-DD) for easy sorting
 - `date_display`: Human-readable date format
 - `kickoff_time`: Match start time (may be None for unscheduled games)
@@ -466,6 +467,7 @@ scrapy crawl games -a parents=competitions.json -a season=2020 > games.json
 {
   "type": "game",
   "href": "/bayern-munich_rb-leipzig/index/spielbericht/4632805",
+  "seasoned_href": "https://www.transfermarkt.co.uk/bayern-munich_rb-leipzig/index/spielbericht/4632805",
   "game_id": 4632805,
   "date_iso": "2025-08-22",
   "date_display": "22/08/25",
@@ -533,16 +535,20 @@ cat competitions.json | scrapy crawl games_urls | grep "Manchester" | head -10 |
 
 **Key Features:**
 - Bypasses competition discovery (parse and extract_game_urls steps)
-- Goes directly to individual game pages
-- Reuses all parsing logic from `games` spider
+- Goes directly to individual game pages via simple parse() method
+- Reuses all parsing logic from `games` spider (parse_game method)
+- Follows same pattern as `players_from_file` spider
 - Ideal for refreshing specific games or targeted scraping
 - Supports both file input and piped input
+- Works seamlessly with output from `games_urls` spider
 
 **Input Format (JSON Lines):**
 ```json
-{"type": "game", "href": "/spielbericht/index/spielbericht/3426901", "game_id": 3426901}
-{"type": "game", "href": "/spielbericht/index/spielbericht/3426916", "game_id": 3426916}
+{"type": "game", "href": "/spielbericht/index/spielbericht/3426901", "seasoned_href": "https://www.transfermarkt.co.uk/...", "game_id": 3426901}
+{"type": "game", "href": "/spielbericht/index/spielbericht/3426916", "seasoned_href": "https://www.transfermarkt.co.uk/...", "game_id": 3426916}
 ```
+
+Note: The `seasoned_href` field is automatically added by `games_urls` spider and used by BaseSpider for URL construction. The `href` field is maintained for compatibility.
 
 **Output Fields:** Identical to `games` spider - extracts comprehensive game data including:
 - Match results and scores (full-time and half-time)

--- a/PLAYER_SCHEMA.md
+++ b/PLAYER_SCHEMA.md
@@ -1,0 +1,512 @@
+# Player Schema Documentation
+
+This document describes the complete schema for player data returned by the `players` spider, with particular focus on the new `national_career` field.
+
+## Schema Overview
+
+Each player object contains profile information and career statistics. The **new addition** is the `national_career` array which contains international career data for all national teams a player has represented.
+
+---
+
+## Complete Player Object
+
+```typescript
+interface Player {
+  // === Metadata ===
+  type: "player";                    // Always "player"
+  href: string;                      // Player profile URL path (e.g., "/lamine-yamal/profil/spieler/937958")
+  parent: object;                    // Parent club entity (structure varies)
+
+  // === Basic Information ===
+  name: string;                      // Full display name (e.g., "Lamine Yamal")
+  last_name: string | null;          // Last name only (e.g., "Yamal")
+  number: string | null;             // Jersey number (e.g., "#10")
+  code: string;                      // URL-decoded player slug (e.g., "lamine-yamal")
+  name_in_home_country: string | null;
+
+  // === Birth & Demographics ===
+  date_of_birth: string | null;      // Format: "Jul 13, 2007"
+  age: string | null;                // Age in years (e.g., "18")
+  place_of_birth: {
+    country: string | null;          // Country name (e.g., "Spain")
+    city: string | null;             // City name (e.g., "Esplugues de Llobregat")
+  };
+  citizenship: string | null;        // Primary citizenship (e.g., "Spain")
+  date_of_death: string | null;      // Only for deceased players
+
+  // === Physical Attributes ===
+  height: string | null;             // Height with unit (e.g., "1,80 m")
+  foot: string | null;               // Preferred foot: "right", "left", "both", or null
+
+  // === Career Information ===
+  position: string | null;           // Primary position (e.g., "Right Winger")
+  status: "active" | "retired" | "deceased";
+  current_club: {
+    href: string;                    // Club URL path
+  } | null;                          // null if retired/deceased
+
+  // === Contract Details ===
+  joined: string | null;             // Join date (e.g., "Jul 1, 2023")
+  contract_expires: string | null;   // Expiry date (e.g., "Jun 30, 2031")
+  day_of_last_contract_extension: string | null;
+  on_loan_from: string | null;       // Club URL if on loan
+  contract_option: string | null;    // Contract option details
+  contract_there_expires: string | null;  // Loan contract expiry
+
+  // === Market Value ===
+  current_market_value: number | null;   // Value in euros (e.g., 200000000)
+  highest_market_value: string | null;   // Formatted string (e.g., "€200.00m")
+
+  // === Additional Info ===
+  player_agent: {
+    href: string | null;             // Agent profile URL
+    name: string | null;             // Agent name
+  };
+  image_url: string | null;          // Profile image URL
+  outfitter: string | null;          // Equipment sponsor (e.g., "Nike")
+  social_media: string[] | undefined; // Array of social media URLs
+
+  // === NEW: National Career ===
+  national_career: NationalTeamCareer[];  // Array of career entries per national team
+}
+```
+
+---
+
+## National Career Schema (NEW)
+
+The `national_career` field is an **array** containing one entry for each national team the player has represented. This includes senior teams and youth teams (U21, U19, U17, etc.).
+
+### Key Characteristics
+
+| Property | Description |
+|----------|-------------|
+| **Type** | `NationalTeamCareer[]` (array) |
+| **Empty State** | `[]` (empty array) if player has no international career |
+| **Ordering** | Senior team first (if exists), then youth teams in dropdown order |
+| **Requests** | One HTTP request per national team to fetch data |
+
+### NationalTeamCareer Object
+
+```typescript
+interface NationalTeamCareer {
+  national_team: NationalTeam;       // Team identification
+  totals: CareerTotals | null;       // Aggregated career statistics
+  competitions: CompetitionStats[];  // Per-competition breakdown
+  matches: MatchRecord[];            // Individual match records
+}
+```
+
+---
+
+## National Team Object
+
+```typescript
+interface NationalTeam {
+  id: string;      // Transfermarkt team ID (e.g., "3375")
+  name: string;    // Team name (e.g., "Spain", "Spain U21", "Spain U19")
+  href: string;    // Team page URL path (e.g., "/spain/startseite/verein/3375")
+}
+```
+
+### Example Values
+
+| id | name | href |
+|----|------|------|
+| `"3375"` | `"Spain"` | `"/spain/startseite/verein/3375"` |
+| `"9567"` | `"Spain U21"` | `"/spain-u21/startseite/verein/9567"` |
+| `"12609"` | `"Spain U19"` | `"/spain-u19/startseite/verein/12609"` |
+| `"12395"` | `"Spain U17"` | `"/spain-u17/startseite/verein/12395"` |
+
+---
+
+## Career Totals Object
+
+Aggregated statistics across all matches for a specific national team.
+
+```typescript
+interface CareerTotals {
+  appearances: number;         // Total matches played (integer >= 0)
+  goals: number;               // Total goals scored (integer >= 0)
+  assists: number;             // Total assists (integer >= 0)
+  yellow_cards: number;        // Total yellow cards (integer >= 0)
+  second_yellow_cards: number; // Total second yellows (integer >= 0)
+  red_cards: number;           // Total red cards (integer >= 0)
+  minutes_played: number;      // Total minutes on pitch (integer >= 0)
+}
+```
+
+### Example
+
+```json
+{
+  "appearances": 23,
+  "goals": 6,
+  "assists": 12,
+  "yellow_cards": 3,
+  "second_yellow_cards": 0,
+  "red_cards": 0,
+  "minutes_played": 1651
+}
+```
+
+### Notes
+- All values are **integers** (not strings)
+- Minimum value is `0` (never negative)
+- `null` is returned for `totals` only if the stats table doesn't exist on the page
+
+---
+
+## Competition Stats Object
+
+Per-competition aggregated statistics.
+
+```typescript
+interface CompetitionStats {
+  name: string | null;         // Competition name (e.g., "UEFA Nations League")
+  href: string | null;         // Competition URL path
+  icon_url: string | null;     // Competition logo URL
+  appearances: number;         // Matches in this competition
+  goals: number;
+  assists: number;
+  yellow_cards: number;
+  second_yellow_cards: number;
+  red_cards: number;
+  minutes_played: number;
+}
+```
+
+### Example
+
+```json
+{
+  "name": "UEFA Nations League",
+  "href": "/uefa-nations-league-a/startseite/pokalwettbewerb/UNLA",
+  "icon_url": "https://tmssl.akamaized.net//images/logo/tiny/unla.png?lm=1512858223",
+  "appearances": 7,
+  "goals": 3,
+  "assists": 1,
+  "yellow_cards": 2,
+  "second_yellow_cards": 0,
+  "red_cards": 0,
+  "minutes_played": 606
+}
+```
+
+### Common Competition Names
+- `"UEFA Euro"`
+- `"UEFA Nations League"`
+- `"European Qualifiers"`
+- `"World Cup qualification"`
+- `"International Friendlies"`
+- `"FIFA World Cup"`
+- `"Copa America"`
+- `"UEFA U21 Championship"`
+
+---
+
+## Match Record Object
+
+Individual match details with performance statistics.
+
+```typescript
+interface MatchRecord {
+  // === Match Identification ===
+  competition: string | null;        // Competition name
+  competition_href: string | null;   // Competition URL with season
+  game_id: number | null;            // Unique match ID (integer)
+  game_href: string | null;          // Match report URL path
+
+  // === Match Details ===
+  matchday: string | null;           // Round/matchday (e.g., "Group A", "Round of 16", "Final")
+  date: string | null;               // Match date (format: "DD/MM/YY", e.g., "08/09/23")
+  venue: string | null;              // "H" (home), "A" (away), or null
+
+  // === Teams ===
+  team: string | null;               // Player's national team name
+  team_href: string | null;          // Team URL with season
+  opponent: string | null;           // Opponent team name
+  opponent_href: string | null;      // Opponent URL with season
+
+  // === Result ===
+  result: string | null;             // Score (e.g., "1:7", "3:0", "2:2")
+  result_type: "win" | "loss" | "draw";  // Match outcome for player's team
+
+  // === Player Performance (when played) ===
+  position: string | null;           // Position code (e.g., "RW", "DM", "CF")
+  position_full: string | null;      // Full position name (e.g., "Right Winger")
+  goals: number;                     // Goals scored in match
+  assists: number;                   // Assists in match
+  yellow_cards: number;              // Yellow cards received (0 or 1)
+  second_yellow_cards: number;       // Second yellow (0 or 1)
+  red_cards: number;                 // Direct red cards (0 or 1)
+  minutes_played: number;            // Minutes on pitch
+
+  // === Unavailability ===
+  unavailable: string | null;        // Reason if didn't play, null if played
+}
+```
+
+### Match States
+
+A match can be in one of two states:
+
+#### 1. Player Participated
+```json
+{
+  "competition": "European Qualifiers",
+  "matchday": "Group A",
+  "date": "08/09/23",
+  "venue": "A",
+  "team": "Spain",
+  "opponent": "Georgia",
+  "result": "1:7",
+  "result_type": "win",
+  "game_id": 3941392,
+  "position": "RW",
+  "position_full": "Right Winger",
+  "goals": 1,
+  "assists": 0,
+  "yellow_cards": 0,
+  "second_yellow_cards": 0,
+  "red_cards": 0,
+  "minutes_played": 46,
+  "unavailable": null
+}
+```
+
+#### 2. Player Unavailable (injury, suspension, etc.)
+```json
+{
+  "competition": "European Qualifiers",
+  "matchday": "Group A",
+  "date": "12/10/23",
+  "venue": "H",
+  "team": "Spain",
+  "opponent": "Scotland",
+  "result": "2:0",
+  "result_type": "win",
+  "game_id": 3941386,
+  "position": null,
+  "position_full": null,
+  "goals": 0,
+  "assists": 0,
+  "yellow_cards": 0,
+  "second_yellow_cards": 0,
+  "red_cards": 0,
+  "minutes_played": 0,
+  "unavailable": "muscular problems"
+}
+```
+
+### Unavailability Reasons
+
+Common values for the `unavailable` field:
+
+| Value | Description |
+|-------|-------------|
+| `null` | Player participated in the match |
+| `"muscular problems"` | Muscle injury |
+| `"strain"` | Muscle strain |
+| `"Ankle injury"` | Ankle injury |
+| `"Groin problems"` | Groin injury |
+| `"Pubalgia"` | Pubic bone inflammation |
+| `"Knee injury"` | Knee injury |
+| `"suspended"` | Suspended due to cards |
+| `"on the bench"` | In squad but didn't play |
+
+### Position Codes
+
+Common position abbreviations:
+
+| Code | Full Name |
+|------|-----------|
+| `"GK"` | Goalkeeper |
+| `"CB"` | Centre-Back |
+| `"LB"` | Left-Back |
+| `"RB"` | Right-Back |
+| `"DM"` | Defensive Midfield |
+| `"CM"` | Central Midfield |
+| `"AM"` | Attacking Midfield |
+| `"LM"` | Left Midfield |
+| `"RM"` | Right Midfield |
+| `"LW"` | Left Winger |
+| `"RW"` | Right Winger |
+| `"CF"` | Centre-Forward |
+| `"SS"` | Second Striker |
+
+### Result Type Logic
+
+The `result_type` is determined by the score and which team the player represents:
+
+- `"win"`: Player's team scored more goals
+- `"loss"`: Player's team scored fewer goals
+- `"draw"`: Equal score
+
+**Note**: For away matches where score shows `"1:7"`, if the player's team (Spain) is the away team and scored 7, this is a `"win"`.
+
+---
+
+## Complete Example
+
+```json
+{
+  "type": "player",
+  "href": "/lamine-yamal/profil/spieler/937958",
+  "parent": { "type": "club", "href": "/fc-barcelona/startseite/verein/131" },
+  "name": "Lamine Yamal",
+  "last_name": "Yamal",
+  "number": "#10",
+  "code": "lamine-yamal",
+  "date_of_birth": "Jul 13, 2007",
+  "age": "18",
+  "place_of_birth": {
+    "country": "Spain",
+    "city": "Esplugues de Llobregat"
+  },
+  "citizenship": "Spain",
+  "height": "1,80 m",
+  "foot": "left",
+  "position": "Right Winger",
+  "status": "active",
+  "current_club": { "href": "/fc-barcelona/startseite/verein/131" },
+  "current_market_value": 200000000,
+  "national_career": [
+    {
+      "national_team": {
+        "id": "3375",
+        "name": "Spain",
+        "href": "/spain/startseite/verein/3375"
+      },
+      "totals": {
+        "appearances": 23,
+        "goals": 6,
+        "assists": 12,
+        "yellow_cards": 3,
+        "second_yellow_cards": 0,
+        "red_cards": 0,
+        "minutes_played": 1651
+      },
+      "competitions": [
+        {
+          "name": "UEFA Nations League",
+          "href": "/uefa-nations-league-a/startseite/pokalwettbewerb/UNLA",
+          "icon_url": "https://tmssl.akamaized.net//images/logo/tiny/unla.png",
+          "appearances": 7,
+          "goals": 3,
+          "assists": 1,
+          "yellow_cards": 2,
+          "second_yellow_cards": 0,
+          "red_cards": 0,
+          "minutes_played": 606
+        }
+      ],
+      "matches": [
+        {
+          "competition": "European Qualifiers",
+          "competition_href": "/european-qualifiers/startseite/pokalwettbewerb/EMQ/saison_id/2022",
+          "matchday": "Group A",
+          "date": "08/09/23",
+          "venue": "A",
+          "team": "Spain",
+          "team_href": "/spanien/spielplan/verein/3375/saison_id/2022",
+          "opponent": "Georgia",
+          "opponent_href": "/georgien/spielplan/verein/3669/saison_id/2022",
+          "result": "1:7",
+          "result_type": "win",
+          "game_id": 3941392,
+          "game_href": "/spielbericht/index/spielbericht/3941392",
+          "position": "RW",
+          "position_full": "Right Winger",
+          "goals": 1,
+          "assists": 0,
+          "yellow_cards": 0,
+          "second_yellow_cards": 0,
+          "red_cards": 0,
+          "minutes_played": 46,
+          "unavailable": null
+        }
+      ]
+    },
+    {
+      "national_team": {
+        "id": "12609",
+        "name": "Spain U19",
+        "href": "/spain-u19/startseite/verein/12609"
+      },
+      "totals": {
+        "appearances": 5,
+        "goals": 2,
+        "assists": 3,
+        "yellow_cards": 0,
+        "second_yellow_cards": 0,
+        "red_cards": 0,
+        "minutes_played": 380
+      },
+      "competitions": [],
+      "matches": []
+    }
+  ]
+}
+```
+
+---
+
+## Edge Cases
+
+### Player with No International Career
+```json
+{
+  "national_career": []
+}
+```
+
+### Player with Only Youth Teams
+```json
+{
+  "national_career": [
+    {
+      "national_team": { "id": "9567", "name": "Spain U21", "href": "..." },
+      "totals": { ... },
+      "competitions": [ ... ],
+      "matches": [ ... ]
+    }
+  ]
+}
+```
+
+### Match Where Player Was on Bench
+```json
+{
+  "position": null,
+  "minutes_played": 0,
+  "unavailable": "on the bench"
+}
+```
+
+### Failed to Fetch National Career (Network Error)
+```json
+{
+  "national_career": []
+}
+```
+The spider gracefully degrades and returns an empty array if fetching fails.
+
+---
+
+## Data Type Summary
+
+| Field | Type | Nullable |
+|-------|------|----------|
+| `national_career` | `array` | No (empty array `[]` if none) |
+| `national_team.id` | `string` | No |
+| `national_team.name` | `string` | No |
+| `totals` | `object` | Yes (null if no table) |
+| `totals.*` | `number` | No (integer >= 0) |
+| `competitions` | `array` | No (can be empty) |
+| `matches` | `array` | No (can be empty) |
+| `match.game_id` | `number` | Yes |
+| `match.result_type` | `string` | No (always one of three values) |
+| `match.unavailable` | `string` | Yes (null if played) |
+| `match.position` | `string` | Yes (null if unavailable) |
+| `match.goals` etc. | `number` | No (integer >= 0) |

--- a/samples/html/casado.html
+++ b/samples/html/casado.html
@@ -1,0 +1,1864 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    
+<script type="text/javascript" data-description="sourcepoint stub code">
+    !function () { var e = function () { var e, t = "__tcfapiLocator", a = [], n = window; for (; n;) { try { if (n.frames[t]) { e = n; break } } catch (e) { } if (n === window.top) break; n = n.parent } e || (!function e() { var a = n.document, r = !!n.frames[t]; if (!r) if (a.body) { var i = a.createElement("iframe"); i.style.cssText = "display:none", i.name = t, a.body.appendChild(i) } else setTimeout(e, 5); return !r }(), n.__tcfapi = function () { for (var e, t = arguments.length, n = new Array(t), r = 0; r < t; r++)n[r] = arguments[r]; if (!n.length) return a; if ("setGdprApplies" === n[0]) n.length > 3 && 2 === parseInt(n[1], 10) && "boolean" == typeof n[3] && (e = n[3], "function" == typeof n[2] && n[2]("set", !0)); else if ("ping" === n[0]) { var i = { gdprApplies: e, cmpLoaded: !1, cmpStatus: "stub" }; "function" == typeof n[2] && n[2](i) } else a.push(n) }, n.addEventListener("message", (function (e) { var t = "string" == typeof e.data, a = {}; try { a = t ? JSON.parse(e.data) : e.data } catch (e) { } var n = a.__tcfapiCall; n && window.__tcfapi(n.command, n.version, (function (a, r) { var i = { __tcfapiReturn: { returnValue: a, success: r, callId: n.callId } }; t && (i = JSON.stringify(i)), e.source.postMessage(i, "*") }), n.parameter) }), !1)) }; "undefined" != typeof module ? module.exports = e : e() }();
+</script>
+<script data-description="sourcepoint configuration">
+window._sp_ = {
+    config: {"accountId":1254,"propertyId":7427,"gdpr":{"consentLanguage":"en","targetingParams":{"acps":"false"}},"baseEndpoint":"https://cdn.privacy-mgmt.com","isSPA":true,"cpPropertyId":"7a84b340"}}
+</script>
+<script src="https://cdn.privacy-mgmt.com/wrapperMessagingWithoutDetection.js" async></script>
+<script type="text/javascript" data-description="contentpass integration">
+    (function() {
+        var cpBaseUrl = 'https://cp.transfermarkt.com';
+        var cpController = cpBaseUrl + '/now.js';
+        var cpPropertyId = '7a84b340';
+
+        !function(C,o,n,t,P,a,s){C['CPObject']=n;C[n]||(C[n]=function(){
+        (C[n].q=C[n].q||[]).push(arguments)});C[n].l=+new Date;a=o.createElement(t);
+        s=o.getElementsByTagName(t)[0];a.src=P;s.parentNode.insertBefore(a,s)}
+        (window,document,'cp','script',cpController);
+
+        !function(C,o,n,t,P){if(!C[n].patched){cp('extension','authenticate');P=C[n].q.push;
+        C[n].q.push=function(a){if(a[0]==='authenticate'){if((o['cookie']||'').indexOf('_cpauthhint=')===-1&&
+        !(C['localStorage']||{})['_cpuser']&&C.location.href.toLowerCase().indexOf('cpauthenticated')===-1){
+        t={isLoggedIn:function(){return false;},hasValidSubscription:function(){return false;}};
+        (typeof a[1]==='function'&&a[1](null,t));C[n].afp=true;P.apply(C[n].q,[['authenticate',null]]);
+        return t;}}P.apply(C[n].q,[a]);}}}
+        (window,document,'cp',false);
+
+        cp('create', cpPropertyId, {
+        baseUrl: cpBaseUrl
+        });
+
+        cp('render', {
+        onFullConsent: function() {
+            console.log('[DEMO] onFullConsent');
+        }
+        })
+    })()
+</script>
+
+<script type="text/javascript" data-description="contentpass sourcepoint fast path">
+(function () {
+    cp('authenticate', function(err, user) {
+        if (err || (!user.isLoggedIn() && !user.hasValidSubscription())) {
+        // console.log('[SPCP] Taking fast path');
+        (function spExecMsg() {
+            if (window._sp_ && window._sp_.executeMessaging) {
+            if (!window._sp_.config.isSPA) {
+                // console.warn('[SPCP] Sourcepoint not in SPA mode!');
+            } else if (window._sp_.version) {
+                // console.log('[SPCP] Sourcepoint already running');
+            } else {
+                // console.log('[SPCP] Starting Sourcepoint');
+                window._sp_.executeMessaging();
+            }
+            } else {
+            // console.log('[SPCP] Sourcepoint not loaded yet. Retrying.');
+            setTimeout(spExecMsg, 10);
+            }
+        })();
+        }
+    });
+    })();
+</script>
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="shortcut icon" sizes="192x192" href="/android-chrome-192x192.png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=no" />
+<meta name="keywords" content="Marc Casadó,FC Barcelona,LaLiga,Spain" />
+<meta name="description" content="Marc Casadó, 22, from Spain ➤ FC Barcelona, since 2024 ➤ Defensive Midfield ➤ Market value: €25.00m ➤ * 14/09/2003 in Sant Pere de Vilamajor, Spain " />
+<meta property="og:type" content="article" />
+<meta property="og:image" content="https://img.a.transfermarkt.technology/portrait/big/636695-1729771427.jpg?lm=1" />
+<meta property="og:description" content="" />
+<meta property="twitter:image" content="https://img.a.transfermarkt.technology/portrait/big/636695-1729771427.jpg?lm=1" />
+<meta property="og:title" content="Marc Casadó - Player profile 25/26" />
+<meta property="twitter:title" content="Marc Casadó - Player profile 25/26" />
+<meta property="og:url" content="https://www.transfermarkt.com/marc-casado/profil/spieler/636695" />
+<link hreflang="de" rel="alternate" href="https://www.transfermarkt.de/marc-casado/profil/spieler/636695" />
+<link hreflang="de-LU" rel="alternate" href="https://www.transfermarkt.de/marc-casado/profil/spieler/636695" />
+<link hreflang="de-AT" rel="alternate" href="https://www.transfermarkt.at/marc-casado/profil/spieler/636695" />
+<link hreflang="de-CH" rel="alternate" href="https://www.transfermarkt.ch/marc-casado/profil/spieler/636695" />
+<link hreflang="tr" rel="alternate" href="https://www.transfermarkt.com.tr/marc-casado/profil/spieler/636695" />
+<link hreflang="it-CH" rel="alternate" href="https://www.transfermarkt.it/marc-casado/profil/spieler/636695" />
+<link hreflang="it" rel="alternate" href="https://www.transfermarkt.it/marc-casado/profil/spieler/636695" />
+<link hreflang="pl" rel="alternate" href="https://www.transfermarkt.pl/marc-casado/profil/spieler/636695" />
+<link hreflang="en-GB" rel="alternate" href="https://www.transfermarkt.co.uk/marc-casado/profil/spieler/636695" />
+<link hreflang="en-IE" rel="alternate" href="https://www.transfermarkt.co.uk/marc-casado/profil/spieler/636695" />
+<link hreflang="es" rel="alternate" href="https://www.transfermarkt.es/marc-casado/profil/spieler/636695" />
+<link hreflang="es-ES" rel="alternate" href="https://www.transfermarkt.es/marc-casado/profil/spieler/636695" />
+<link hreflang="es-CL" rel="alternate" href="https://www.transfermarkt.es/marc-casado/profil/spieler/636695" />
+<link hreflang="es-VE" rel="alternate" href="https://www.transfermarkt.es/marc-casado/profil/spieler/636695" />
+<link hreflang="es-EC" rel="alternate" href="https://www.transfermarkt.es/marc-casado/profil/spieler/636695" />
+<link hreflang="es-CU" rel="alternate" href="https://www.transfermarkt.es/marc-casado/profil/spieler/636695" />
+<link hreflang="nl" rel="alternate" href="https://www.transfermarkt.nl/marc-casado/profil/spieler/636695" />
+<link hreflang="pt" rel="alternate" href="https://www.transfermarkt.pt/marc-casado/profil/spieler/636695" />
+<link hreflang="ru" rel="alternate" href="https://www.transfermarkt.world/marc-casado/profil/spieler/636695" />
+<link hreflang="fr-CH" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/profil/spieler/636695" />
+<link hreflang="fr" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/profil/spieler/636695" />
+<link hreflang="fr-CA" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/profil/spieler/636695" />
+<link hreflang="fr-CI" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/profil/spieler/636695" />
+<link hreflang="fr-LU" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/profil/spieler/636695" />
+<link hreflang="fr-BE" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/profil/spieler/636695" />
+<link hreflang="pt-BR" rel="alternate" href="https://www.transfermarkt.com.br/marc-casado/profil/spieler/636695" />
+<link hreflang="en-US" rel="alternate" href="https://www.transfermarkt.us/marc-casado/profil/spieler/636695" />
+<link hreflang="en-CA" rel="alternate" href="https://www.transfermarkt.us/marc-casado/profil/spieler/636695" />
+<link hreflang="en-IN" rel="alternate" href="https://www.transfermarkt.co.in/marc-casado/profil/spieler/636695" />
+<link hreflang="en-ZA" rel="alternate" href="https://www.transfermarkt.co.za/marc-casado/profil/spieler/636695" />
+<link hreflang="x-default" rel="alternate" href="https://www.transfermarkt.com/marc-casado/profil/spieler/636695" />
+<link hreflang="en" rel="alternate" href="https://www.transfermarkt.com/marc-casado/profil/spieler/636695" />
+<link hreflang="nl-BE" rel="alternate" href="https://www.transfermarkt.be/marc-casado/profil/spieler/636695" />
+<link hreflang="ro" rel="alternate" href="https://www.transfermarkt.ro/marc-casado/profil/spieler/636695" />
+<link hreflang="el-GR" rel="alternate" href="https://www.transfermarkt.gr/marc-casado/profil/spieler/636695" />
+<link hreflang="ko-KR" rel="alternate" href="https://www.transfermarkt.co.kr/marc-casado/profil/spieler/636695" />
+<link hreflang="es-AR" rel="alternate" href="https://www.transfermarkt.com.ar/marc-casado/profil/spieler/636695" />
+<link hreflang="es-MX" rel="alternate" href="https://www.transfermarkt.mx/marc-casado/profil/spieler/636695" />
+<link hreflang="es-CO" rel="alternate" href="https://www.transfermarkt.co/marc-casado/profil/spieler/636695" />
+<link hreflang="es-PE" rel="alternate" href="https://www.transfermarkt.pe/marc-casado/profil/spieler/636695" />
+<link hreflang="ms" rel="alternate" href="https://www.transfermarkt.my/marc-casado/profil/spieler/636695" />
+<link hreflang="ja" rel="alternate" href="https://www.transfermarkt.jp/marc-casado/profil/spieler/636695" />
+<link hreflang="id" rel="alternate" href="https://www.transfermarkt.co.id/marc-casado/profil/spieler/636695" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-main.min.css?lm=1767953971" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/stylesheets/main_desktop.css?lm=1767953048" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-discover.min.css?lm=1767953971" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-button-list.min.css?lm=1767953971" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-link-list.min.css?lm=1767953971" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-print.min.css?lm=1767953971" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/stylesheets/main.css?lm=1767953048" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-player-profile.min.css?lm=1767953971" />
+<style type="text/css">
+/*<![CDATA[*/
+@keyframes heim {
+    0%   {width: 0%;}
+    100% {width: 0%}
+}
+@keyframes gast {
+    0%   {width: 0%;}
+    100% {width: 0%}
+}
+.fav-voting__home {
+    animation-name: heim;
+    animation-duration: 4s;
+}
+.fav-voting__visitor {
+    animation-name: gast;
+    animation-duration: 4s;
+}
+/*]]>*/
+</style>
+<style type="text/css">
+/*<![CDATA[*/
+
+                .ad-placement-background {
+                    background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxODk2IDgwNyI+CiAgPHBhdGggZD0iTTEwNTYuMyA1MzIuNGMwLTE3LjEtMTUuMy0yOS4yLTMyLTMzLjktMTEuNS0zLjItNjUuNi0xMC42LTExNi45IDAtMTQuNiAzLTYxLjUgMTkuNy02MC43IDM4LjQuNSAxMC42IDE4LjQgMTEuOSAyNS43IDExLjkgMzguNyAwIDQ5LjEtMjIuNyA4Mi42LTIyLjdzMjcuMi0xLjQgMjcuMiAxNC44LTMzLjMgMjEuNS0zNy4yIDIyYy0xNy40IDIuNC04NC42IDEyLjQtMTA4LjYgMjUuMy0zNi40IDE5LjUtNDcgNDAuNi00NyA1Mi42IDAgMzcuNyA1MC43IDQwLjYgNzEuNyA0MC42IDMxLjQgMCA0NS42LTEwLjkgNzEuNy0xMC45czMyLjYgNi41IDQyIDYuOWM3LjMuMyAxMy45LTEuNCAxOS45LTMuMyAxNy4yLTUuNSAxOC4yLTIzLjEgMjMuMy0zNC42IDExLjEtMjUuNSAyMS42LTUxLjMgMzEuMS03Ny4yIDMuNC05LjkgNy4zLTE5LjggNy4zLTI5LjlabS0xNDQuOCAxMDljLTYuNyAxLjUtOS44IDIuMS0xNy40IDIuNC04LjUuMy0yNi43LTMuNS0yNi43LTE1LjMgMC0yNC40IDYzLjUtMzMuMiA3Mi43LTMzLjIgMTEuMi0uNCAxOC4zIDIuNyAxOC4zIDkuOSAwIDIwLjgtNDQuNiAzNS43LTQ2LjkgMzYuMlpNNzkzLjkgNTA3LjVjLTQ0LjctMjcuOS0xMDcuMiA1LTEzMC41IDUtMzEuOCAwLTMwLjctMTIuOC02NC44LTE1LTY5LTQuMS05MCAxMi4yLTEwNS4yIDEyLjJzLTkuMy04LjMtMjEuNS02LjdjLTEzLjMgMi4yLTE1LjUgNS0xOS4xIDEwLTQuNSA2LjMtNTMuNSAxMzguOC01Ni41IDE0Ni4xLTExLjEgMjYuMyA1NS43IDI5LjUgNzAuOCA4LjcgMzkuNy01NC45IDMwLjktMTE0LjIgODAuOS0xMjMuOSAxMS44LTIuMyAyMi4zLTIuNiAzMC40IDkuMWwuNC44YzcuMiAxMy4zLTUuNCAzOS44LTEzLjggNjAuNS00LjEgMTAtMTYuNiA0Mi43LTE1LjUgNTQgMS45IDIxLjEgNjYuOCAxNC4xIDc1LjYtMi4xIDE5LjMtMzUuNiAyMy4xLTk2LjkgNDQuMS0xMTMuNCAyNS42LTIwIDQ5LjItNC43IDUxLjMgNC41IDQuMiAxOC4yLTEzLjUgNTIuNy0yMyA3Mi44LTEzLjQgMjguNS03LjMgNTEuMSAyNyA1MS4yIDExLjQgMCAyNy00LjQgMzMuNy0xNC4xIDUuNy04LjMgMTQuNS0zMS42IDI3LjQtNjYuNSAxNC4xLTM4LjEgMjkuMi04MCA4LjMtOTMuMVpNMTIzNSA1MTQuMmMtMS40LTExLTEyLTE1LjYtMjEuMS0xNS4yLTYuNC4yLTE4LjggNS4yLTI4LjYgNS4yLTEwLjcgMC0xNS4yLTIuMS0yOS43LTQuNy0xNy41LTMuMi0zMy4yLTIuNi00My43IDAtMTYuMiA0LTI4LjcgMjAtMzIuMSAzMi44LTUuOCAyMS0xNi42IDQyLjQtMjQuNyA2My4zLTguNyAyMi41LTIzLjcgNjIuMi0yNC40IDcwLjEtLjYgNi45IDcuMiAxNS43IDE1LjIgMTUuNyAwIDAgMzEgLjMgMzcuMS0uMiAyNS0yLjIgMzQuNi0zNi4yIDQwLjMtNTAuNiA0LjctMTEuNyA5LjUtMjQgMTQuMi0zNS42IDMuMS03LjcgNy4zLTE5LjEgMTYuMS0yNy4zIDE3LjItMTYgMzcuNi0xNiA1Ni4zLTIwLjggMTYuOS00LjQgMjYuOC0xOSAyNS4yLTMyLjZaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTM3LjcgNDEuOXY3MjEuN2gxODA5LjhWNDEuOUgzNy43Wm0xNzg5LjEgNzAxSDU4LjNWNjIuNWgxNzY4LjV2NjgwLjRaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTE2MzIuNCA0OTUuOGMtNy44LTMuMS0xNS4yLTYuMi0xMy42LTE0LjIgMy0xNC41IDQuMy0yNC4zLjctMzAuNC0zLjYtNi0xMi4yLTguMy0yOC45LTcuOC0yNi43LjgtMzYuMiA3LjktNDIgMTcuMS01LjkgOS4xLTguMiAyMC4zLTIwLjQgMjkuMi03LjUgNS40LTE1LjkgNy45LTIzIDExLjItNy4xIDMuMy0xNC44IDguOC0xNC44IDE2LjMuMSA4LjQgNSAxMC45IDEwLjEgMTMuOCA1IDIuOSAxMC4yIDUuMyAxMC43IDEwLjguMyAxNi42LTcuOCAzNS43LTE2IDU0LjYtOC4zIDE4LjgtMTYuNyAzNy4zLTE2LjkgNTIuOC0xLjYgMzYuOSA0Ni43IDMxLjkgNTguMSAzMiAxNi4yLS4yIDU3LjkgMi40IDU4LjYtMjkuOCAwLTktNy43LTEyLTE1LjItMTUuMi03LjUtMy4zLTE0LjgtNi44LTE0LjEtMTYuOS4zLTMuNCA1LjQtMTguNSAxMS0zMy44IDUuNi0xNS4zIDExLjctMzAuNiAxMy45LTM0LjMgNi4yLTEwLjQgMjAuOC0xNS40IDMzLjgtMjAuNCAxMy01IDI0LjQtMTAgMjQuNC0yMC40cy04LjMtMTEuMy0xNi4xLTE0LjVaTTE0MDcuOSA1MDkuNmMtMTMuOCA1LTc3LjUgNDktODguMiAzNC41LTguMy0xNC4xIDMxLjctNzguMyAyNS44LTkwLjgtNy45LTE2LjYtNDQuMi05LTUyLjUtNS0xNS4xIDcuMy0yMC4xIDI0LjgtMjUuNyAzOC44LTEwLjcgMjYuOC02NS42IDE2Ny44LTY4LjkgMTc4LjMtNS42IDE3LjkgNTQuNyAzMCA3NC44LTE2LjcgNi4zLTE0LjUgMjQuNi0zMi4zIDQwLjktMzIuMyAzMS45IDAgMjYuNyA2My43IDcwLjQgNjQuNyA0LjggMCAyMy41LjUgMzYuNy01LjcgMjMuNC0xMS4xLTI4LTc2LjUtMjgtOTYuNnM4Ni44LTU3LjEgNzkuNi02Ny43Yy05LjItMTMuNS00Ny45LTcuNy02NS0xLjVaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTMzMC41IDQxMS43WiIgZmlsbD0iI2I0MTAxZiIvPgogIDxwYXRoIGQ9Ik0xNDI0LjQgMjUyLjZoNDAuM2M0LjIgMCAzMiAwIDMxLjMtMTYuOC0uNi0xMy41LTE4LjctMTcuNS0zMy44LTE3LjYtMTIuOS0uMi01NC4yIDYuNS01NC4yIDIzLjZzNS42IDkuOSAxNi41IDEwLjlaTTU3My40IDI4Mi44Yy05LjIgMC03Mi43IDguOC03Mi43IDMzLjJzMTguMiAxNS43IDI2LjcgMTUuM2M3LjYtLjMgMTAuNy0uOSAxNy40LTIuMyAyLjMtLjUgNDYuOS0xNS40IDQ2LjktMzYuMnMtNy4xLTEwLjMtMTguMy05LjlaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZmlsbD0iI2FmMjAwOSIgZD0iTTM0MC40IDc1NC4xeiIvPgogIDxwYXRoIGQ9Ik0zNzcuMiA3MDYuOGMtNi0yMS42LTI1LjktMzYuMS00OC4zLTM1LjItMy44LjEtNy41LjctMTEuMSAxLjctMjUuNiA3LjItNDAuNiAzMy45LTMzLjQgNTkuNSA2LjEgMjEuNiAyNS45IDM2LjEgNDguMyAzNS4yIDMuOC0uMiA3LjUtLjcgMTEuMS0xLjggMTIuNC0zLjUgMjIuNy0xMS42IDI5LTIyLjggNi4zLTExLjIgNy45LTI0LjIgNC40LTM2LjdabS0xNS40IDMwLjVjLTQuNyA4LjMtMTIuMyAxNC4zLTIxLjQgMTYuOC0yLjcuOC01LjUgMS4yLTguMiAxLjNoLTEuNGMtMTYgMC0yOS45LTEwLjUtMzQuMy0yNi0uOS0zLjItMS4zLTYuNC0xLjMtOS42IDAtMTUuNiAxMC4zLTI5LjkgMjYtMzQuMyAyLjctLjcgNS41LTEuMiA4LjItMS4zaDEuNGMxNS45IDAgMjkuOSAxMC41IDM0LjIgMjYgLjkgMy4yIDEuMyA2LjQgMS4zIDkuNiAwIDYtMS42IDEyLTQuNiAxNy40WiIgZmlsbD0iI2Q3ZDdkNyIvPgogIDxwYXRoIGZpbGw9IiNhZjIwMDkiIGQ9Ik0zMjEuMiA2ODUuNXpNMzMwLjQgMzA4LjV6TTMyMy4yIDMwOS43eiIvPgogIDxwYXRoIGQ9Ik0xODA2LjggODEuOEg3OC4zVjQwNmgxNjZjLTM3LjkgMTYuNS03OC4yIDM0LjEtOTEuOCA0MC0xNC40IDYuMS0yMi4xIDIyLjEtMTcuOSAzNy4yIDMuOCAxMy40IDE2LjEgMjIuOCAzMCAyMi44aDEuMmMyLjQgMCA0LjgtLjUgNy4yLTEuMSAxLS4zIDIuMi0uNiAzLjUtMS4xaC4zYzAtLjEgNjgtMzAuOCA2OC0zMC44bC05LjIgMjIuOEwxOTMuOSA1OThsLS4yLjVjLTIuMiA2LjItMi41IDEyLjgtLjcgMTkgMy44IDEzLjYgMTUuOCAyMi44IDI5LjkgMjIuOGgxLjJjLjcgMCAxLjUgMCAyLjEtLjJsLTM0LjQgODQuN3MtMTMuNyAyOC45IDE0LjUgNDEuMWMzMy4xIDE0LjMgNDMuNi0xOC40IDQzLjYtMTguNGw4MC44LTE5OC44IDQxLjItMTAxLjUgMTQuNCA1LjgtMTQuMiAzNC45LTEgMi43LS4yLjljLTEuMiA1LjEtMS4xIDEwLjUuMyAxNS42IDMuOCAxMy40IDE2LjEgMjIuOCAzMCAyMi44aDEuMWMyIDAgNS0uMyA4LjEtMS40IDEwLjctMy43IDE2LjMtOS4yIDIwLjYtMjAuNWwyNS4zLTYyLjJjMi4yLTUuNCA0LTExLjUgMS43LTE5LjQtMi40LTguNy03LjctMTUuMS0xNS0xOC4xbC0uNC0uMmMtLjUtLjItMS4yLS41LTItLjhsLTMuMi0xLjNoMTM2OS40VjgxLjhaTTM0Mi4zIDE4Ni45YzEwLjUtMi42IDI2LjItMy4yIDQzLjcgMCAxNC41IDIuNiAxOSA0LjcgMjkuNyA0LjcgOS44IDAgMjUuNS00LjggMzEuOS00LjkgOC42LS4xIDIxLjUgMi42IDIxLjUgMTQuM3MtMTUuMSAzMC40LTI5IDMzLjdjLTE4LjggNC42LTM5IDQuMy01Ni4xIDIwLjMtOC44IDguMi0xMyAxOS42LTE2LjEgMjcuMy0zIDcuNS02LjEgMTUuMy05LjIgMjMtNS42LTQuNC0xMi4zLTcuNS0xOS42LTguNy0uNSAwLTEuMS0uMi0xLjctLjNoLS4yYy0uNSAwLTEtLjEtMS41LS4ySDMzMGMtMi42IDAtNS4yLjQtNy43IDEtLjguMi0xLjcuNC0yLjUuNi0xLjQuNC0yLjguOS00LjEgMS40cy0yLjcgMS4xLTMuOSAxLjhjLS42LjMtMS4zLjctMS45IDEtNi44IDMuOS0xMi41IDkuNi0xNi40IDE2LjYtNC4zIDcuNi02LjIgMTYuMi01LjUgMjQuNy4yIDIuOS43IDUuOCAxLjUgOC42LjIuOC41IDEuNS43IDIuMyAwIC4yLjEuMy4yLjUuMi42LjQgMS4yLjcgMS44IDAgLjEuMS4yLjIuNGwuOSAyLjFjMS44IDMuNyA0LjEgNy4yIDYuOCAxMC4yaC0yMi43Yy04IDAtMTUuOC04LjgtMTUuMi0xNS43LjctNy45IDE1LjgtNDcuNSAyNC40LTcwLjEgOC0yMC45IDE4LjktNDIuMyAyNC43LTYzLjMgMy41LTEyLjcgMTUuOS0yOC44IDMyLjEtMzIuOFptMjAuNiAxNTIuOWMwIDEzLjctOSAyNi4zLTIyLjggMzAuMS0yLjQuNy00LjggMS03LjIgMS4xaC0xLjNjLTE0IDAtMjYuMy05LjItMzAuMS0yMi44LS44LTIuOC0xLjItNS42LTEuMi04LjQgMC0xMy43IDktMjYuMyAyMi44LTMwLjEgMi4zLS43IDQuOC0xIDcuMi0xLjFoMS4zYzE0IDAgMjYuMiA5LjMgMzAgMjIuOS44IDIuOCAxLjIgNS42IDEuMiA4LjRabS0xNzUuNCAyOWMtMTEuNC0uMS01OS43IDQuOS01OC4xLTMyIC4yLTE1LjQgOC42LTMzLjkgMTYuOS01Mi44IDguMy0xOC44IDE2LjQtMzcuOSAxNi01NC42LS41LTUuNi01LjctOC0xMC43LTEwLjgtNS0yLjktMTAtNS40LTEwLjEtMTMuOCAwLTcuNSA3LjYtMTMgMTQuNy0xNi4zIDcuMS0zLjMgMTUuNi01LjggMjMtMTEuMiAxMi4zLTguOSAxNC42LTIwLjEgMjAuNC0yOS4yIDUuOS05LjEgMTUuMy0xNi4yIDQyLjEtMTcuMSAxNi44LS41IDI1LjMgMS43IDI4LjkgNy44IDMuNiA2IDIuMyAxNS44LS43IDMwLjQtMS42IDggNS44IDExLjEgMTMuNiAxNC4yIDcuOCAzLjIgMTYuMSA2LjMgMTYuMSAxNC41cy0xMS40IDE1LjUtMjQuNCAyMC40Yy0xMyA1LTI3LjUgOS45LTMzLjggMjAuNC0yLjIgMy43LTguMyAxOS0xMy45IDM0LjMtNS42IDE1LjMtMTAuOCAzMC40LTExIDMzLjgtLjcgMTAuMSA2LjYgMTMuNiAxNC4xIDE2LjkgNy41IDMuMyAxNS4yIDYuMyAxNS4yIDE1LjItLjcgMzIuMi00Mi4zIDI5LjctNTguNiAyOS44Wm0zNiAyNTguOGgtLjhjLTguMyAwLTE1LjYtNS41LTE3LjgtMTMuNi0uNS0xLjctLjctMy4zLS43LTUgMC0yLjEuNC00LjMgMS4xLTYuM3MzNy05MC42IDM3LTkwLjZsMzQuMSAxMy45LTM2LjcgOTAuMmMtMi4yIDUuMi02LjcgOS4xLTEyLjIgMTAuNy0xLjMuNC0yLjQuNy00IC44Wm0xNC40IDExNS4zYy0yLjUgNi4xLTYuNiAxMC40LTEyLjcgMTIuMS0xLjQuNC0yLjkuNi00LjMuN2gtLjhjLTguMyAwLTE1LjEtNS40LTE3LjQtMTMuNC0uNS0xLjctLjctMy40LS43LTUuMSAwLTEuNS4yLTMgLjYtNC41cy4zLTEuMy4zLTEuM2wuNy0yIDgxLjItMTk5LjkgMzQuMSAxMy45LTgxIDE5OS41Wk00MzguNCA0MjBjMi4xLjkgMy44IDIuMyA1IDQuMSAxLjIgMS43IDIuMSAzLjcgMi42IDUuNy40IDEuMy42IDIuNi42IDMuOCAwIDIuMy0uNyA0LjYtMS44IDcuNGwtMjUuNCA2Mi40Yy0xLjQgMy44LTIuOCA2LjUtNC44IDguNi0yIDIuMS00LjYgMy40LTguMSA0LjYtMS41LjUtMyAuNy00LjQuN2gtLjhjLTguNCAwLTE1LjctNS41LTE3LjktMTMuNi0uNS0xLjYtLjctMy4zLS43LTVzLjItMi45LjUtNC4zdi0uMmwuNy0xLjggMTguOC00Ni4zLTM3LjYtMTUuMy00MS4yIDEwMS41LTc1LjctMzAuOC0xLjEtLjUgMjEuMy01Mi42LTk2LjMgNDMuNWMtLjguMy0xLjUuNS0yLjIuNy0xLjQuNC0yLjguNi00LjMuN2gtLjhjLTguMyAwLTE1LjctNS41LTE3LjktMTMuNi0uNS0xLjctLjctMy40LS43LTUgMC03LjMgNC40LTE0LjIgMTEuNC0xNy4yIDI0LjctMTAuNyAxMzUuNS01OSAxNjMuMi03MS4xIDQtMS43IDYuMi0yLjcgNi4zLTIuNyAzLjMtMS40IDYuOC0yLjEgMTAuMi0yLjJoMS4yYzQgMCA3LjIuOCAxMS42IDIuNnM4Ni4zIDM1LjEgODYuMyAzNS4xYy43LjIgMS40LjYgMi4xLjlabTE4OS41LTU4LjRjLTYgMS45LTEyLjYgMy43LTE5LjkgMy4zLTkuNS0uNC0zOS42LTYuOS00Mi02LjktMjYuMSAwLTQwLjMgMTAuOS03MS43IDEwLjlzLTcxLjctMi44LTcxLjctNDAuNiAxMC42LTMzLjEgNDctNTIuNmMyNC0xMi45IDkxLjItMjIuOSAxMDguNi0yNS4zIDMuOS0uNSAzNy4yLTMuMSAzNy4yLTIycy0yMS43LTE0LjktMjcuMi0xNC45Yy0zMy41IDAtNDMuOSAyMi44LTgyLjYgMjIuOHMtMjUuMi0xLjItMjUuNy0xMS45Yy0uOC0xOC42IDQ2LjEtMzUuMyA2MC43LTM4LjMgNTEuMy0xMC42IDEwNS41LTMuMiAxMTYuOSAwIDE2LjcgNC42IDMyIDE2LjggMzIgMzMuOXMtMy45IDIwLTcuMyAyOS45Yy05LjQgMjYtMTkuOSA1MS43LTMxIDc3LjItNS4xIDExLjUtNi4xIDI5LTIzLjMgMzQuNVptMjE2LjYgNy4xYy05LjEgMC0yOS4yIDEuNC0yOS4xLTE0LjcgMC0xMC4zIDM1LjYtODQuNSAzNS42LTEwNC40cy0xNi4yLTIyLjMtMjguMi0yMi4zYy0yOC42IDAtNTEuMSAyMC4yLTYzLjIgNTYuMS02LjcgMjAtMjMuMiA1OS43LTI4IDY2LjktMTAuNSAxNS41LTI3IDE4LjYtNDAuOCAxOC42cy0yOC42LS4yLTI4LjYtMTcuMyAyMy45LTY0LjYgMjcuMy03Mi41YzUuNy0xMy41IDE0LjMtMzcuNiAyMC4xLTUxLjYgMTMuNy0zMy40IDE4LjYtMzguMiA1Mi0zOC43IDEwLjUtLjEgMjguNSA1LjIgNDUgNC44IDIxLjQtLjUgNDYuOS05LjIgNjguNy04LjkgMTUuOC4yIDU4IC43IDU5LjggMzQuMS45IDE2LTI3LjcgNzYuMy0zNC43IDk0LjktMTguMiA0OC40LTE4LjggNTQuOS01NS45IDU0LjlabTE4Ni43LTEzMy42YzEuMSAyNS42IDEyNC41IDguMyAxMTYuMyA2MC42LTE0LjYgOTIuOC0yMjcuNiA4NS45LTIzNi43IDQyLjQtMi4xLTEwLjIgMTguMi0yNiAzNi4zLTI1LjMgMjQuNiAxIDM3LjEgMTcuNiA2My43IDE3LjZzNTEuNS0yLjQgNTMuMS0yMWMuOS0xMC43LTIwLjUtMTQuNi0zNi41LTE2LjMtMTExLjUtMTEuNC03Ny43LTYwLTcwLTY5LjkgNDUuMS01OC4yIDIwOC40LTUwIDIwOC40LTE3LjJzLTI5LjcgMjcuMS00Ni41IDIyLjNjLTI2LjctNy42LTg5LjMtMjAuNS04OC4xIDYuN1ptMjU0LjIgNWMtNi4zIDEwLjEtOS4zIDIyLjEtMTMuNCAzMi42LTguNiAyMi4xLTE4LjggNDMuMi0yNi4xIDY1LjMtOS4xIDI3LjQtMzEgMzEtNDkuNyAzMXMtMzEuNiAwLTMxLjYtMTUuOSA0MC42LTk1IDQwLjYtMTE0LjgtMjIuMy0xNy40LTIyLjMtMjguMyA4LjYtMTQuMiAxNi43LTE3LjhjOS4xLTQgMjIuOS03LjEgMzAuOS0xOC44IDI2LjktMzkuMSA1NC44LTUwLjggOTQuNC01MC44czQ0LjMgMTEuOCA0NC40IDE1LjdjLjcgMjIuOS0zMy43IDI3LjktNDYuNyAzNS44LTEuNiAxLTMuNyAzLjgtMy43IDYuMiAwIDEwLjEgMjIuOCA3LjIgMjIuOCAyMS44cy0zOC4yIDI0LjEtNDEuOSAyNS40Yy01LjIgMi0xMC43IDYuNy0xNC4zIDEyLjRabTEzMy4xIDkxLjdjMzMuMyAwIDU4LjgtMjUuOCA4My44LTI1LjhzMjguMiA0LjQgMjguMiAxNi44LTMwLjEgMjQuNy0zOC45IDI5LjNjLTE5LjMgMTAuMS04Ny44IDI1LjMtMTMzLjggMTAuNS01OS0xOS02NC4yLTU5LjctMzUuMy0xMDcuOSAzMC44LTUxLjMgOTUtNzMuMiAxNTIuOC03My4yczg2LjYgMTEgOTIuMyA1OS45YzEuOCAxNS41LTIgMjkuMi0xNi44IDM3LjYtMTkuOCAxMS4yLTExNi42IDEtMTQ1LjUgNi4xLTExLjEgMi0yNS4xIDYuOS0yNS4xIDIwLjRzMjMuOSAyNi4zIDM4LjMgMjYuM1ptMzExLjgtOTcuNmMtMTguNyA0LjgtMzkuMSA0LjgtNTYuMyAyMC44LTguOCA4LjItMTMgMTkuNi0xNi4xIDI3LjMtNC43IDExLjYtOS41IDIzLjktMTQuMiAzNS42LTUuNyAxNC40LTE1LjMgNDguNC00MC4zIDUwLjYtNiAuNS0zNy4xLjItMzcuMS4yLTggMC0xNS44LTguOC0xNS4yLTE1LjguNy03LjkgMTUuOC00Ny42IDI0LjQtNzAuMSA4LTIwLjkgMTguOS00Mi4zIDI0LjctNjMuMyAzLjUtMTIuNyAxNS45LTI4LjggMzIuMS0zMi44IDEwLjUtMi42IDI2LjItMy4yIDQzLjcgMCAxNC41IDIuNiAxOSA0LjcgMjkuNyA0LjcgOS44IDAgMjIuMi01IDI4LjYtNS4yIDkuMS0uMyAxOS43IDQuMyAyMS4xIDE1LjIgMS43IDEzLjYtOC4zIDI4LjItMjUuMiAzMi42WiIgZmlsbD0iI2Q3ZDdkNyIvPgogIDxwYXRoIGZpbGw9IiNhZjIwMDkiIGQ9Ik0yMjUuMiA3NTV6Ii8+Cjwvc3ZnPgo=);
+                    background-size: 143px 61px;
+                    background-repeat: no-repeat;
+                    background-position: center 20px;
+                }
+/*]]>*/
+</style>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/vendor/jquery.min.js?lm=1767953049"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/ads/tisoomi.com.min.js?lm=1767955802"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/main.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/chosen.ajaxaddition.jquery.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/functions.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/main_desktop.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/chosen.jquery.js?lm=1767953048"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+console.info("%c [TM-ADs] Initialize Ads on domain .com (spieler/profil)", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Tisoomi is active -> add Tisoomi script", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot PerformPlayer (/58778164/d_content_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format PerformPlayer", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot rectangle1 (/58778164/d_side_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format rectangle1", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot rectangle2 (/58778164/d_side_2) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format rectangle2", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot skyscraper (/58778164/d_right_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format skyscraper", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot billboard (/58778164/d_top_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format billboard", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot fullsize_contentad (/58778164/d_bottom_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format fullsize_contentad", "background: #282828; color: #bada55")
+    var oddsServe = function(placement,competition,match,node) {
+        if (!node){
+            var s=document.readyState==='loading'?document.getElementsByTagName('script'):[];
+            node=s.length?s[s.length-1].parentNode:null;
+        }
+        oddsServe.queue.push({contentUnitId:placement,competition:competition,match:match,node:node});
+    }
+    
+    oddsServe.onInit=function(callbacks){
+        if (typeof window.__tcfapi === 'function') {
+            __tcfapi('addEventListener', 2, function(tcdata, success) {
+                let tcf20compatibleString;
+                if(success) {
+                    if (tcdata.eventStatus === 'useractioncomplete') {
+                        tcf20compatibleString = tcdata.tcString;
+                    } else if (tcdata.eventStatus === 'tcloaded') {
+                        tcf20compatibleString = tcdata.tcString;
+                    }
+                    callbacks.setGdprOptions({
+                        gdpr:1,
+                        gdpr_pd:1,
+                        gdpr_consent:tcf20compatibleString,
+                    });
+                }
+            });
+        } else {
+            console.warn('E2: __tcfapi not found');
+        }
+    };
+    oddsServe.options={gdpr_wait:true};
+    oddsServe.queue=[];
+console.info("%c [TM-ADs] Add adslot configuration for PerformPlayer | rectangle1 | rectangle2 | skyscraper | billboard | fullsize_contentad", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Adslots without configuration: ADTAG_CONTENT_BODY_1 | inreadSpecial | profile_above_outbrain | fireplace | skyscraper-left-bound | skyscraperbtf | richmedia | 1by1px", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Register slots with JS vendor lib", "background: #282828; color: #bada55")
+console.warn("%c [TM-ADs] Duplicate placement IDs found: /58778164", "background: #282828; color: #bada55")
+window.addEventListener('load', () => {
+  const offset = window.matchMedia('(max-width: 768px)').matches ? 80 : 120;
+  document.querySelectorAll('[data-sticky]').forEach(node => {
+    const parent = node.parentElement;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) {
+        parent.style.position = 'sticky';
+        parent.style.top = `${offset}px`;
+        parent.style.zIndex = 12000000;
+        setTimeout(() => {
+          parent.style.removeProperty('position');
+          parent.style.removeProperty('top');
+          parent.style.removeProperty('z-index');
+        }, parseInt(node.dataset?.sticky) || 3000);
+        observer.unobserve(parent);
+      }
+    }, { rootMargin: `-${offset}px 0px 0px 0px`, threshold: 1 });
+    observer.observe(parent);
+  });
+});
+PWT = {};
+window.googletag = window.googletag || {cmd: []};
+googletag.cmd.push(() => {
+  window.ad_d_top_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_top_1",
+    [[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90], "fluid"],
+    "d_top_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_side_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_side_1",
+    [[336, 280], [300, 250], [250, 250], "fluid"],
+    "d_side_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_side_2 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_side_2",
+    [[336, 280], [300, 250], [250, 250], "fluid"],
+    "d_side_2"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  window.ad_d_right_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_right_1",
+    [[300, 600], [336, 280], [320, 480], [300, 250], [240, 400], [200, 600], [160, 600], [120, 600]],
+    "d_right_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_content_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_content_1",
+    [[679, 382], [336, 280], [300, 250], [250, 250], [1, 1], "fluid"],
+    "d_content_1"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  window.ad_d_bottom_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_bottom_1",
+    [[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90], "fluid"],
+    "d_bottom_1"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  googletag.pubads().setCentering(true);
+  googletag.pubads().disableInitialLoad();
+  googletag.pubads().setTargeting("cg1", ["spieler"]);
+  googletag.pubads().setTargeting("URL", ["www.transfermarkt.com"]);
+  googletag.enableServices();
+});
+!function(t,$,e,s,i,a,o){$[t]||($[t]={init:function(){_("i",arguments)},fetchBids:function(){_("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]});function _(e,s){$[t]._Q.push([e,s])}}("apstag",window,document,"script","//c.amazon-adsystem.com/aax2/apstag.js"),apstag.init({pubID:"5134",adServer:"googletag"});const initAmazonAdBids=(t,$)=>{($&&"tcloaded"===t.eventStatus||"useractioncomplete"===t.eventStatus)&&apstag.fetchBids(
+  {slots:[
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_top_1",
+      slotID:"d_top_1",
+      sizes:[[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_side_1",
+      slotID:"d_side_1",
+      sizes:[[336, 280], [300, 250], [250, 250]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_side_2",
+      slotID:"d_side_2",
+      sizes:[[336, 280], [300, 250], [250, 250]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_right_1",
+      slotID:"d_right_1",
+      sizes:[[300, 600], [336, 280], [320, 480], [300, 250], [240, 400], [200, 600], [160, 600], [120, 600]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_content_1",
+      slotID:"d_content_1",
+      sizes:[[679, 382], [336, 280], [300, 250], [250, 250], [1, 1]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_bottom_1",
+      slotID:"d_bottom_1",
+      sizes:[[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90]],
+    },
+  ],
+  timeout:2e3},
+  function(t){googletag.cmd.push(function(){apstag.setDisplayBids()})})};
+"function"==typeof window.__tcfapi&&window.__tcfapi("addEventListener",2,initAmazonAdBids);
+
+document.addEventListener("DOMContentLoaded", () => {
+  const closeButtonSticky = document.getElementById("sticky-ad-close-button");
+  if(closeButtonSticky) {
+    closeButtonSticky.addEventListener("touchstart", function(e) {
+      e.preventDefault();
+      var elem = this.parentNode;
+      elem.parentNode.removeChild(elem);
+    }, {passive: false});
+  }
+});
+
+console.info("%c [TM-ADs] Render ad slots js for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Added external ad script https://securepubads.g.doubleclick.net/tag/js/gpt.js for googleadvertising on wettbewerbe_profile_spieler", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Added external ad script https://c.amazon-adsystem.com/aax2/apstag.js for googleadvertising on wettbewerbe_profile_spieler", "background: #282828; color: #bada55")
+/*]]>*/
+</script>
+<title>Marc Casadó - Player profile 25/26 | Transfermarkt</title>
+    <link rel="apple-touch-icon-precomposed" href="/apple-touch-icon-152x152.png">
+    
+<script type="text/javascript">
+   tmData = {
+       loggedIn : "0",
+       tmTraffic: "0",
+   };
+</script>
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+    let utmVars = {
+        eVar1: urlParams.get('utm_campaign'),
+        eVar6: urlParams.get('utm_source'),
+        eVar24: urlParams.get('utm_medium')
+    };
+    Object.keys(utmVars).forEach((k) => utmVars[k] == null && delete utmVars[k]);
+
+    window.tmAnalyticsDataLayer = window.tmAnalyticsDataLayer || [];
+    window.tmAnalytics = {
+        dimensions: {
+            eVar27: 'Marc Casadó (636695)',
+			eVar3: 'FC Barcelona (131)',
+			eVar4: 'LaLiga (ES1)',
+			eVar5: 'Spain',
+			eVar10: 'https://www.transfermarkt.com/marc-casado/profil/spieler/636695',
+			...utmVars,
+            evar19: window.location.href,
+            eVar35 : '',
+			eVar37 : '',
+    },
+    properties: {
+        prop2: 'statistik',
+		prop3: 'spieler',
+		prop4: 'profil',
+		prop5: '636695',
+		prop11: '636695',
+		prop14: 'statistik_spieler_profil_636695',
+		prop9: window.location.hostname,
+        prop10: window.location.href,
+        prop1 : 'false',
+    },
+    pageDetails: {
+        pageViews: {
+            value: 1
+        },
+        isErrorPage: 'false',
+            isHomepage: 'false',
+            name: 'Marc Casadó - Player profile 25/26 | Transfermarkt',
+            URL: window.location.href,
+            server: 'prod-tm-web-server-11217'
+    },
+    };
+
+function tmEventForLink(category, aTag, label) {
+    const url = new URL(aTag.href);
+    const link = url.pathname + url.search;
+    tmEvent(category, link, label);
+}
+
+function tmEvent(category, action, label, detail = '') {
+    if (typeof gtag === 'function') {
+        gtag('event',
+            action,
+            {
+                'event_category': category,
+                'event_label': label
+            }
+        );
+    }
+
+    const ev = {
+        event: 'tmEvent',
+        tmEvent: {
+            customDimensions: {
+                eVars: {
+                    ...tmAnalytics.dimensions
+                },
+                props: {
+                    prop6: category,
+                    prop7: action,
+                    prop8: label,
+                    prop17: detail,
+                    ...tmAnalytics.properties
+                }
+            },
+            event1to100: {
+                event7: {
+                    value: 1
+                },
+                event8: null,
+            },
+            session: {
+                web: {
+                    webInteraction: {
+                        linkClicks: {
+                            value: 1
+                        }
+                    },
+                    webPageDetails: {
+                        ...tmAnalytics.pageDetails,
+                        ...{
+                            pageViews: {
+                                value: null
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+     if (!window._satellite) {
+        once = false;
+        window._satellite = { _monitors: [{
+            ruleTriggered: (e) => {
+                if (once) {
+                    return;
+                }
+                once = true;
+                setTimeout(() => {
+                    tmAnalyticsDataLayer.push(ev);
+                    tmAnalyticsDataLayer.push(function (dl) {
+                        const state = dl.getState();
+                    });
+                }, 1);
+            }
+        }] };
+    } else {
+        tmAnalyticsDataLayer.push(ev);
+        tmAnalyticsDataLayer.push(function (dl) {
+            const state = dl.getState();
+        });
+    }
+}
+function tmTrackingAndAds() {
+    if (typeof gtag === 'function') {
+        gtag("event", "page_view", {
+            page_path: "/jsContent" + window.location.pathname
+        });
+    }
+
+    tmAnalyticsDataLayer.push({
+        event: 'tmTrackingAndAds',
+        tmTrackingAndAds: {
+            customDimensions: {
+                eVars: tmAnalytics.dimensions,
+                props: tmAnalytics.properties
+            },
+            event1to100: {
+                event7: null,
+                event8: {
+                    value: 1
+                }
+            },
+            session: {
+                web: {
+                    webInteraction: {
+                        linkClicks: {
+                            value: null
+                        }
+                    },
+                    webPageDetails: {
+                        ...tmAnalytics.pageDetails,
+                        ...{
+                            pageViews: {
+                                value: 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+    tmAnalyticsDataLayer.push(function (dl) {
+        const state = dl.getState();
+    });
+}
+function tmTiming(value, name, event_category, event_label) {
+    console.log('tmTiming', value, name, event_category, event_label);
+}
+
+        !function(e,a,n,t){var i=e.head;if(i){
+            if (a) return;
+            var o=e.createElement("style");
+            o.id="alloy-prehiding",o.innerText=n,i.appendChild(o),setTimeout(function(){o.parentNode&&o.parentNode.removeChild(o)},t)}}
+        (document, document.location.href.indexOf("adobe_authoring_enabled") !== -1, ".personalization-container { opacity: 0 !important }", 3000);
+
+            !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
+                []).push(o),n[o]=function(){var u=arguments;return new Promise(
+                function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
+            (window,["alloy"]);
+</script>
+<tm-consent
+    type="adobe"
+    no-checkbox
+    embed="PHNjcmlwdCBhc3luYyBzcmM9Imh0dHBzOi8vYXNzZXRzLmFkb2JlZHRtLmNvbS83Y2FkY2E5NWRkOWEvY2Q0YWI4ODRkMjMxL2xhdW5jaC0wMTI3MmI0MDBjNjUubWluLmpzIj48L3NjcmlwdD4=">
+</tm-consent>
+
+    <script type="text/javascript" src="https://tmssl.akamaized.net//ads/ads.js"></script>
+    <script type="text/javascript">
+        window.tmGaId = "UA-3816204-13";
+
+        function sendIvwData() {}
+    </script>
+            <link rel="canonical" href="https://www.transfermarkt.com/marc-casado/profil/spieler/636695">
+    </head>
+
+<body class="desktop " itemscope itemtype="http://schema.org/WebPage" data-tm-tld="com" data-cmp-layer-id="910164" data-db-name="com-der-zauberzwerg">
+    
+                <tm-domain-note></tm-domain-note>
+        <div id="main">
+                    <button id="back-to-top" title="Nach oben">
+                <svg xmlns="http://www.w3.org/2000/svg" width="17.795" height="10.009" viewBox="0 0 17.795 10.009">
+                    <path id="angle-up" d="M20.683,17.01a1.112,1.112,0,0,1-.786-.326l-7-7-7,7a1.112,1.112,0,1,1-1.573-1.573l7.785-7.785a1.112,1.112,0,0,1,1.573,0l7.785,7.785a1.112,1.112,0,0,1-.786,1.9Z" transform="translate(-4 -7)" fill="#fff"/>
+                </svg>
+            </button>
+            <div class="werbung-skyscraper-left-bound-container">
+                            </div>
+            <div class="werbung-skyscraper-container">
+                <script type="text/javascript">//RWGzztV("skyscraper")</script>
+<div class="ad-placement-note werbung werbung-skyscraper"  data-ad-placement-note="Advertisement">
+  <div id="d_right_1" style="min-height: 600px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_right_1");
+        let has_d_right_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_right_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_right_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_right_1]);
+                has_d_right_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_right_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+            </div>
+
+            <div class="werbung-skyscraperbtf-container">
+                            </div>
+        
+        <div id="tm-overlay"></div>
+
+                    <div class="tm-header__box">
+                <!-- logo  -->
+                <a href="/" class="tm-header__logo" onclick="tmEvent('hauptnavi', '/', 'TM-Logo');">
+                    <img src="https://tmsi.akamaized.net/head/tm_logo_rebrush.svg"
+                         height="62"
+                         width="156"
+                         title="Transfermarkt"
+                         alt="Transfermarkt"
+                    >
+                </a>
+
+                <!-- domainswitcher  -->
+                <div class="domin-swicher">
+                    <tm-domain-switcher
+                        tld="com"
+                        translations='{&quot;chooseYourDomain&quot;:&quot;Choose your domain&quot;}'></tm-domain-switcher>
+                </div>
+
+                <!-- live -->
+                <tm-live-match-count
+                    class="tm-header__live"
+                    auto-request                    content='{&quot;liveMatches&quot;:&quot;Live matches&quot;,&quot;liveMatch&quot;:&quot;Live maches&quot;,&quot;live&quot;:&quot;Live&quot;}'></tm-live-match-count>
+
+                <!-- Search -->
+                                    <div class="tm-header__search " id="schnellsuche-platz">
+                        <form name="schnellsuche" id="schnellsuche" class="tm-header__form" action="/schnellsuche/ergebnis/schnellsuche">
+                            <input type="text" name="query" class="tm-header__input--search-field" onClick="" placeholder="Enter your search term" autocorrect="off" spellcheck="false" value="" />
+                            <button type="submit" value="" class="tm-header__input--search-send" alt="Search">
+                                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="18" viewBox="0 0 18 18">
+                                    <path d="M17.825,16.847 L14.28,13.303 C17.072,9.987 16.756,5.061 13.563,2.13 C10.37,-0.8 5.435,-0.695 2.37,2.37 C-0.695,5.435 -0.8,10.37 2.13,13.563 C5.061,16.756 9.987,17.072 13.303,14.28 L16.847,17.825 C17.121,18.069 17.538,18.057 17.797,17.797 C18.057,17.538 18.069,17.121 17.825,16.847 z M1.418,8.108 C1.417,4.413 4.412,1.417 8.107,1.416 C11.802,1.415 14.798,4.411 14.799,8.106 C14.799,11.801 11.804,14.797 8.108,14.797 C4.414,14.797 1.419,11.803 1.418,8.108 z" fill="#000" />
+                                </svg>
+                            </button>
+                        </form>
+                        <a href="/detailsuche/spielerdetail/suche" title="to detailed player search" id="detailsuche-head" class="tm-header__search-detail">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="18" viewBox="0, 0, 18, 18">
+                                <path d="M3.138,3.558 C3.137,1.593 4.727,0 6.69,0 C8.652,-0 10.243,1.592 10.243,3.556 C10.243,5.521 8.653,7.113 6.69,7.113 C4.729,7.113 3.138,5.522 3.138,3.558 z M8.233,13.187 C8.261,11.778 8.861,10.442 9.893,9.486 C9.967,9.418 9.997,9.315 9.971,9.219 C9.946,9.119 9.863,9.044 9.76,9.03 C9.331,8.938 8.893,8.893 8.454,8.895 L4.906,8.895 C3.583,8.808 2.286,9.298 1.35,10.239 C0.414,11.179 -0.07,12.479 0.021,13.804 C-0.085,14.656 0.209,15.509 0.817,16.114 C1.425,16.72 2.279,17.009 3.13,16.897 L9.266,16.897 C9.372,16.895 9.467,16.831 9.508,16.732 C9.549,16.634 9.527,16.521 9.453,16.444 C8.665,15.544 8.232,14.387 8.236,13.191 z M17.805,17.804 C17.68,17.93 17.511,18 17.334,18 C17.158,18 16.989,17.93 16.864,17.804 L15.237,16.177 C13.686,17.242 11.58,16.949 10.378,15.501 C9.176,14.052 9.274,11.926 10.604,10.594 C11.934,9.263 14.058,9.165 15.505,10.368 C16.952,11.571 17.244,13.68 16.181,15.233 L17.805,16.866 C18.065,17.126 18.065,17.548 17.805,17.808 z M15.484,13.182 C15.484,11.911 14.455,10.881 13.186,10.881 C11.917,10.881 10.888,11.911 10.888,13.182 C10.888,14.452 11.917,15.482 13.186,15.482 C14.455,15.482 15.484,14.452 15.484,13.182 z" fill="#000" />
+                            </svg>
+                        </a>
+                    </div>
+                
+                <!-- login button -->
+                <div class="tm-header__login">
+                    <tm-userbox translations='{&quot;addFavorite&quot;:&quot;Add favourite&quot;,&quot;adminArea&quot;:&quot;Admin area&quot;,&quot;adminTools&quot;:&quot;Admin tools&quot;,&quot;allFavoriteLinkText&quot;:&quot;Go to all my favourite links&quot;,&quot;applyAsModOrDatascout&quot;:&quot;Apply as a moderator or datascout&quot;,&quot;checkAllNews&quot;:&quot;Check all news&quot;,&quot;checkAllRumours&quot;:&quot;Check all rumours&quot;,&quot;chooseYourDomain&quot;:&quot;Choose your domain&quot;,&quot;clickAgain&quot;:&quot;Click again to copy shortlink to your clipboard&quot;,&quot;clubBoard&quot;:&quot;Club forum&quot;,&quot;copied&quot;:&quot;Copied to your clipboard&quot;,&quot;copyLink&quot;:&quot;Link kopieren&quot;,&quot;createAccount&quot;:&quot;Create your account&quot;,&quot;createNewMessage&quot;:&quot;Create a new message&quot;,&quot;createShortlink&quot;:&quot;create a shortlink&quot;,&quot;createShortNews&quot;:&quot;Create memo&quot;,&quot;dashboard&quot;:&quot;Overview&quot;,&quot;dataAdministration&quot;:&quot;Data administration&quot;,&quot;debug&quot;:&quot;Debug&quot;,&quot;deleteAll&quot;:&quot;Delete all&quot;,&quot;deleteConfirm&quot;:&quot;Yes, delete all&quot;,&quot;editText&quot;:&quot;Edit&quot;,&quot;forgotPassword&quot;:&quot;Forgot password?&quot;,&quot;forgotUsername&quot;:&quot;Forgot username?&quot;,&quot;forgotLoginDetails&quot;:&quot;Forgot your login details?&quot;,&quot;forum&quot;:&quot;forum&quot;,&quot;groundhoppingTool&quot;:&quot;Groundhopping Tool&quot;,&quot;lastMatch&quot;:&quot;last match&quot;,&quot;signin&quot;:&quot;Log in&quot;,&quot;login&quot;:&quot;Login&quot;,&quot;logOut&quot;:&quot;Log out&quot;,&quot;manageFavorites&quot;:&quot;Manage favourites&quot;,&quot;marketValue&quot;:&quot;market value&quot;,&quot;matchplan&quot;:&quot;Schedule&quot;,&quot;messages&quot;:&quot;Private messages&quot;,&quot;myClub&quot;:&quot;My club&quot;,&quot;myClubText&quot;:&quot;With a Transfermarkt account you can register your favourite club and find all important information about your club (matches, news, quick links). &quot;,&quot;myDreamTeam&quot;:&quot;My dream team&quot;,&quot;myFavorites&quot;:&quot;My favourites&quot;,&quot;myFavoritesText&quot;:&quot;With a Transfermarkt account, you can save any page as a favourite and then access it with one click.&quot;,&quot;myProfile&quot;:&quot;My profile&quot;,&quot;news&quot;:&quot;News&quot;,&quot;newsAdministration&quot;:&quot;News administration&quot;,&quot;nextMatch&quot;:&quot;next match&quot;,&quot;noNewNotifications&quot;:&quot;No new notifications&quot;,&quot;notifications&quot;:&quot;Notifications&quot;,&quot;notificationsDeletedAutomatically&quot;:&quot;Note: Notifications are automatically deleted after 30 days.&quot;,&quot;notifyDeleteMessage&quot;:&quot;Private messages older than 45 days will be deleted from time to time (except for data scouts and moderators)&quot;,&quot;or&quot;:&quot;or&quot;,&quot;other&quot;:&quot;Miscellaneous&quot;,&quot;overview&quot;:&quot;overview&quot;,&quot;password&quot;:&quot;Password&quot;,&quot;playerRatings&quot;:&quot;Player ratings&quot;,&quot;playerWatchlist&quot;:&quot;Players Watchlist&quot;,&quot;profile&quot;:&quot;Profile&quot;,&quot;progDebug&quot;:&quot;Prog. depanare&quot;,&quot;progProfile&quot;:&quot;Prog. profile&quot;,&quot;registerNow&quot;:&quot;Sign up now&quot;,&quot;rememberMe&quot;:&quot;Remember me&quot;,&quot;removeFavorite&quot;:&quot;Delete favourite&quot;,&quot;rumors&quot;:&quot;Rumours&quot;,&quot;schedule&quot;:&quot;Schedule&quot;,&quot;setting&quot;:&quot;Settings&quot;,&quot;shortlink&quot;:&quot;Shortlink&quot;,&quot;shortLinkCreationError&quot;:&quot;An Error occured creating the shortlink.&quot;,&quot;shortLinkHasBeenCreated&quot;:&quot;Shortlink has been created an was copied to your clipboard&quot;,&quot;shortLinkIsBeingCreated&quot;:&quot;Creating shortlink ...&quot;,&quot;showAllMessages&quot;:&quot;Show all messages&quot;,&quot;totalMarketValue&quot;:&quot;Total market value&quot;,&quot;translation&quot;:&quot;Translation&quot;,&quot;username&quot;:&quot;Username&quot;,&quot;whyRegister&quot;:&quot;Why register?&quot;,&quot;Bitte korrigieren Sie die markierten Felder&quot;:&quot;Bitte korrigieren Sie die markierten Felder&quot;,&quot;mindestensDreiZeichen&quot;:&quot;At least three characters&quot;,&quot;mindestensAchtZeichen&quot;:&quot;At least eight characters&quot;,&quot;pleaseCorrectFields&quot;:&quot;profil&quot;,&quot;minThreeCharacters&quot;:&quot;At least three characters&quot;,&quot;minEightCharacters&quot;:&quot;At least eight characters&quot;,&quot;noAtCharacter&quot;:&quot;The @ character is not allowed in the username&quot;,&quot;agentProfile&quot;:&quot;My Agency Profile&quot;}' page-title="Marc Casadó - Player profile 25/26 | Transfermarkt" tld="com" agent-profile=""  />
+                </div>
+            </div>
+        
+        
+                        <!-- mobile end -->
+            <nav class="main-navbar">
+                                    <a href="/" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/', 'DISCOVER')">
+                        DISCOVER                    </a>
+                                    <a href="/navigation/transfersundgeruechte" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/transfersundgeruechte', 'TRANSFERS & RUMOURS')">
+                        TRANSFERS & RUMOURS                    </a>
+                                    <a href="/navigation/marktwerte" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/marktwerte', 'MARKET VALUES')">
+                        MARKET VALUES                    </a>
+                                    <a href="/navigation/wettbewerbe" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/wettbewerbe', 'COMPETITIONS')">
+                        COMPETITIONS                    </a>
+                                    <a href="/navigation/statistiken" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/statistiken', 'STATISTICS')">
+                        STATISTICS                    </a>
+                                    <a href="/navigation/community" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/community', 'COMMUNITY')">
+                        COMMUNITY                    </a>
+                                    <a href="/navigation/gaming" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/gaming', 'GAMING')">
+                        GAMING                    </a>
+                                <div class="main-navbar__details">
+                    <div class="hamburger">
+                        <em></em>
+                    </div>
+                    <div class="dropdown-layer"></div>
+                    <div class="main-navbar__dropdown">
+                                                            <div class="recommendation">
+        
+    
+                            <div class="tm-discover__hero-container tm-discover__hero-container-grid tm-discover-container-grid">
+                    
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--two-thirds  "><span class="tm-discover__h2">Recommendations</span><ul class="tm-button-list"><li><a
+                        href="/uefa-champions-league/startseite/wettbewerb/CL"
+                        title="Champions League"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/uefa-champions-league/startseite/wettbewerb/CL' , '1_1', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/cl.png?lm=1626810555"
+                            alt="UEFA Champions League"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/premier-league/startseite/wettbewerb/GB1"
+                        title="Premier League"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/premier-league/startseite/wettbewerb/GB1' , '1_2', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/gb1.png?lm=1521104656"
+                            alt="Premier League"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/laliga/startseite/wettbewerb/ES1"
+                        title="LaLiga"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/laliga/startseite/wettbewerb/ES1' , '1_3', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/es1.png?lm=1725974302"
+                            alt="LaLiga"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/serie-a/startseite/wettbewerb/IT1"
+                        title="Serie A"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/serie-a/startseite/wettbewerb/IT1' , '1_4', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/it1.png?lm=1656073460"
+                            alt="Serie A"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/bundesliga/startseite/wettbewerb/L1"
+                        title="Bundesliga"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/bundesliga/startseite/wettbewerb/L1' , '1_5', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/l1.png?lm=1525905518"
+                            alt="Bundesliga"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/champions-league/startseite/pokalwettbewerb/CL"
+                        title="UEFA Champions League"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/champions-league/startseite/pokalwettbewerb/CL' , '1_6', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/fr1.png?lm=1732280518"
+                            alt="Ligue 1"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li></ul></section>
+                                                                                
+        
+    
+                
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--one-third  tm-button-list__desktop"><span class="tm-discover__h2">Player agents</span><ul class="tm-button-list"><li><a
+                        href="/agent-support/beraterIndex/berater"
+                        title="Agent support"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/agent-support/beraterIndex/berater' , '2_1', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-support.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>support</a></li><li><a
+                        href="/berater/beraterfirmenuebersicht/berater"
+                        title="Agent statistics"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/berater/beraterfirmenuebersicht/berater' , '2_2', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-statistic.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>statistics</a></li><li><a
+                        href="/premium-service/berater"
+                        title="Premium service"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/premium-service/berater' , '2_3', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/premium-service.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Premium<br>service</a></li></ul></section>
+                                                                                
+        
+    
+                
+                                            
+<section class="tm-link-list-container tm-link-list--full ">
+        <div
+        class="tm-link-list-element"
+        role="navigation"
+        aria-label=""
+    >
+                    
+                        
+                                            <ul
+    class="tm-link-list-unordered   recommendation__links"
+>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/neuestetransfers"
+                    title="Latest transfers"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/neuestetransfers' , '3_1','linkList');"
+                >
+                    Latest transfers
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/rumour-mill/detail/forum/154"
+                    title="Rumour Mill"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/rumour-mill/detail/forum/154' , '3_2','linkList');"
+                >
+                    Rumour Mill
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/aktuell/newsarchiv"
+                    title="All news"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/aktuell/newsarchiv' , '3_3','linkList');"
+                >
+                    All news
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/whatsMyValue"
+                    title="What's my value?"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/whatsMyValue' , '3_4','linkList');"
+                >
+                    What's my value?
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/spieler-statistik/wertvollstespieler/marktwertetop"
+                    title="Most valuable players in the world"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/spieler-statistik/wertvollstespieler/marktwertetop' , '3_5','linkList');"
+                >
+                    Most valuable players in the world
+                </a>
+                    </li>
+    </ul>
+                                            <ul
+    class="tm-link-list-unordered   recommendation__links"
+>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/spieler-statistik/wertvollstemannschaften/marktwertetop"
+                    title="Most valuable clubs in the world"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/spieler-statistik/wertvollstemannschaften/marktwertetop' , '3_6','linkList');"
+                >
+                    Most valuable clubs in the world
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/marktwertanalyse/detail/forum/357"
+                    title="Market value analysis"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/marktwertanalyse/detail/forum/357' , '3_7','linkList');"
+                >
+                    Market value analysis
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/vertragslosespieler"
+                    title="Free agents"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/vertragslosespieler' , '3_8','linkList');"
+                >
+                    Free agents
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/endendevertraege"
+                    title="Contracts ending"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/endendevertraege' , '3_9','linkList');"
+                >
+                    Contracts ending
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/betting/"
+                    title="Betting"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/betting/' , '3_10','linkList');"
+                >
+                    Betting
+                </a>
+                    </li>
+    </ul>
+                        </div>
+
+    </section>
+                                                                        
+        
+    
+                
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--full  tm-button-list__mobile"><span class="tm-discover__h2">Player agents</span><ul class="tm-button-list"><li><a
+                        href="/agent-support/beraterIndex/berater"
+                        title="Agent support"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/agent-support/beraterIndex/berater' , '4_1', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-support.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>support</a></li><li><a
+                        href="/berater/beraterfirmenuebersicht/berater"
+                        title="Agent statistics"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/berater/beraterfirmenuebersicht/berater' , '4_2', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-statistic.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>statistics</a></li><li><a
+                        href="/premium-service/berater"
+                        title="Premium service"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/premium-service/berater' , '4_3', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/premium-service.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Premium<br>service</a></li></ul></section>
+                                                                                
+                    </div>
+        
+    </div>
+                                                </div>
+                </div>
+            </nav>
+
+            <div class="quick-select-wrapper">
+    
+    <tm-quick-select defaultCountry="157" defaultCompetition="ES1" defaultClub="131" defaultPlayer="636695" dropdown-visible="" translations='{"home":"Home","country":"Country","competition":"Competition","club":"Club","player":"Player","attack":"Striker","midfield":"Midfielder","defense":"Defender","goalkeeper":"Goalkeeper"}'>
+    </tm-quick-select>
+</div>
+
+            
+        
+        <script type="text/javascript">//RWGzztV("billboard")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-billboard"  data-ad-placement-note="Advertisement">
+  <div id="d_top_1" style="min-width: 1024px; min-height: 250px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_top_1");
+        let has_d_top_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_top_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_top_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_top_1]);
+                has_d_top_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_top_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+
+
+        
+        <main id="tm-main">
+            <tm-consent no-checkbox type="teads" embed=""></tm-consent>
+    <div id="modal-1" class="modal micromodal-slide" aria-hidden="true" tabindex="1">
+        <div class="modal__overlay" tabindex="-1" data-custom-close>
+            <div
+                class="modal__container"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="modal-1-title"
+                data-custom-close
+                >
+                <header class="modal__header">
+                    <button
+                        class="modal__close modal__close--profile-img"
+                        aria-label="Close modal"
+                        data-custom-close
+                        >
+                    </button>
+                </header>
+                <div id="modal-1-content" class="modal__content">
+                                        <img src='https://img.a.transfermarkt.technology/portrait/big/636695-1729771427.jpg?lm=1' alt='Marc Casadó' title='Marc Casadó' data-custom-close loading="lazy">
+                </div>
+            </div>
+        </div>
+    </div>
+
+<header class="data-header" itemscope itemtype="https://schema.org/Person">
+                    <div class="data-header__headline-container">
+            <h1 class="data-header__headline-wrapper">
+                                    <span class="data-header__shirt-number">
+                        #17                    </span>
+                                Marc <strong>Casadó</strong>            </h1>
+                            <tm-watchlist player-id="636695"></tm-watchlist>
+                                </div>
+                    <div class="data-header__badge-container">
+                                                    <a href="/marc-casado/erfolge/spieler/636695" title="Spanish champion" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/11.png?lm=1520606997" title="Spanish champion" alt="Spanish champion" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                    <a href="/marc-casado/erfolge/spieler/636695" title="Spanish cup winner" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/94.png?lm=1520606999" title="Spanish cup winner" alt="Spanish cup winner" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                    <a href="/marc-casado/erfolge/spieler/636695" title="Spanish Super Cup winner" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/93.png?lm=1520606999" title="Spanish Super Cup winner" alt="Spanish Super Cup winner" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                    <a href="/marc-casado/erfolge/spieler/636695" title="Torneio Internacional Algarve U17" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/538.png?lm=1747150597" title="Torneio Internacional Algarve U17" alt="Torneio Internacional Algarve U17" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                                    <a href="/marc-casado/erfolge/spieler/636695"
+                       title="All titles & victories"
+                       class="data-header__success-more"
+                    >
+                    </a>
+                            </div>
+        
+                    <div class="data-header__box--big">
+                                    <a href="/fc-barcelona/startseite/verein/131" class="data-header__box__club-link">
+                                            <img srcset="
+                            https://tmssl.akamaized.net//images/wappen/normquad/131.png?lm=1406739548 1x,
+                            https://tmssl.akamaized.net//images/wappen/homepageWappen150x150/131.png?lm=1406739548 2x
+                            " alt="FC Barcelona" height="100" width="100" />
+                                        </a>
+                                <div class="data-header__club-info">
+                    <span class="data-header__club" itemprop="affiliation">
+                        <a title="FC Barcelona" href="/fc-barcelona/startseite/verein/131">Barcelona</a>                    </span><br />                    
+                                                                            <span class="data-header__league">
+                                    <a class="data-header__league-link" href="/laliga/startseite/wettbewerb/ES1">
+                                        <img src="https://tmssl.akamaized.net//images/logo/verytiny/es1.png?lm=1725974302" title="LaLiga" alt="LaLiga" class="" />LaLiga                                    </a>
+                                </span>
+                                                                            <span class="data-header__label">League level:
+                                <span class="data-header__content">
+                                    <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />First Tier                                </span>
+                            </span>
+                                                                                                        <span class="data-header__label">Joined: <span class="data-header__content">01/07/2024</span></span>
+                            <span class="data-header__label">Contract expires: <span class="data-header__content">30/06/2028</span></span>
+                                                            </div>
+            </div>
+        
+        <div class="data-header__profile-container">
+                            <div class="modal-trigger" data-custom-open="modal-1" id="fotoauswahlOeffnen" style="cursor:pointer" onclick="tmEvent('spielerprofil','click','profilbild');">
+            
+                                <img src="https://img.a.transfermarkt.technology/portrait/header/636695-1729771427.jpg?lm=1" title="Marc Casadó" alt="Marc Casadó" class="data-header__profile-image" height="181" width="139" /><div class="bildquelle"><span title="IMAGO">IMAGO</span></div>
+                                    <span class="modal-trigger-icon">+</span>
+                </div>
+                        </div>
+        <div class="data-header__info-box ">
+            <div class="data-header__details">
+                <ul class="data-header__items">
+                                            <li class="data-header__label">Date of birth/Age:
+                            <span itemprop="birthDate" class="data-header__content">
+                                14/09/2003 (22)                            </span>
+                        </li>
+
+                                                    <li class="data-header__label">Place of birth:
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />                                <span class="data-header__content" itemprop="birthPlace">
+                                    <span class="cp" title="Sant Pere de Vilamajor">Sant Pere de ...</span>                                </span>
+                            </li>
+                        
+                                            <li class="data-header__label">Citizenship:
+                            <span itemprop="nationality" class="data-header__content">
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />                                Spain                            </span>
+                        </li>
+                                    </ul>
+                <ul class="data-header__items">
+                                            <li class="data-header__label">Height:
+                            <span itemprop="height" class="data-header__content">
+                                1,72 m                            </span>
+                        </li>
+                    
+                    <li class="data-header__label">Position:
+                        <span class="data-header__content">
+                            Defensive Midfield                        </span>
+                    </li>
+                    
+                        <li class="data-header__label">Agent:
+                            <span class="data-header__content data-header__content--vertical-aligned">
+                                
+                                    <a onclick="tmEvent(&quot;spielerprofil&quot;, &quot;click&quot;, &quot;berater-header-premium&quot;)" href="/wasserman/beraterfirma/berater/440">Wasserman</a>                                                                            <img class="data-header__verified-logo" src="https://tmsi.akamaized.net/berater/verified_premium_minified.png" alt="verified" title="verified" height="13" width="13">
+                                                                                                </span>
+                        </li>
+
+                                    </ul>
+                <ul class="data-header__items">
+                                            <li for="" class="data-header__label">
+                                                            Former International:
+                                                        <span class="data-header__content">
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen flagge" /><a title="Spain" href="/spanien/startseite/verein/3375">Spain</a>                            </span>
+                        </li>
+                                                    <li class="data-header__label">Caps/Goals:
+                                <a class="data-header__content data-header__content--highlight" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375">2                                </a>/
+                                <a class="data-header__content data-header__content--highlight" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375">0                                </a>
+                            </li>
+                        <li class="data-header__label theme-button">
+    </li>
+                </ul>
+            </div>
+        </div>
+            
+            <div class="data-header__box--small">
+                <a href="/marc-casado/marktwertverlauf/spieler/636695" class="data-header__market-value-wrapper"><span class="waehrung">€</span>25.00<span class="waehrung">m</span>                <p class="data-header__last-update">Last update: 12/12/2025</p></a>
+            </div>
+
+            
+    </header>
+<a href="https://www.transfermarkt.com/transfer-focus-what-do-the-traditional-big-six-clubs-need-this-january-/view/news/431862"
+        target="1"
+    class="db mt10"
+        onclick="tmEvent('banner', 'https://www.transfermarkt.com/transfer-focus-what-do-the-traditional-big-six-clubs-need-this-january-/view/news/431862', 'd-day-banner');"
+>
+    <img
+        loading="lazy"
+        src="https://dzjovqk3zamsg.cloudfront.net/big-six-desktop-banner.jpg"
+        width="1034"
+        height="99"
+        alt="deadline-day banner"
+    >
+</a>
+
+<script type="text/javascript">
+    (() => {
+        const cookies = document.cookie
+            .split(';')
+            .map(c => c.trim().split('='))
+            .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+        const isContentPassUser = cookies?._cpauthhint !== undefined;
+        if (isContentPassUser) {
+            const adNodes = document.querySelectorAll('.ad-placement-note');
+            adNodes.forEach(node => node.remove());
+        }
+    })();
+</script><tm-subnavigation
+    controller="spieler"
+    id="636695"
+    season=""
+    section="spieler"
+    style="display: block; margin: 0 5px;">
+</tm-subnavigation>
+<div class="row">
+    <div class="large-8 columns">
+         
+ <tm-player-performance-stage
+    class="box tm-player-performance"
+    style="display: none"
+    competition-id="ES1"
+    player-id="636695"
+    translations='{"performanceDataButton":"Performance Data","galleryButton":"Gallery ","possibleGames":"{spiel} Possible games","possibleGame":"{spiel} Statistics","games":"Appearances","goals":"Goals","assists":"Assists","yellowCard":"Yellow card","yellowCards":"Yellow cards","secondYellowCard":"Second yellow card","secondYellowCards":"Second yellows","redCard":"Red card","redCards":"Red cards","startEleven":"Starting eleven","minutesPlayed":"Minutes","goalsContributed":"Goal participation","detailedStatsLink":"Detailed performance data","cleanSheets":"Clean sheets","goalsConceded":"Goals conceded","performanceSeason":"Performance data :saison","blockedPenaltyPercent":"Penalty Saves","advertisement":"Advertisement","ufl":{"stage":"Football Video Game","button":"PLAY NOW FOR FREE!","available":"Available on","legalLong":"\u00a9 2026, XTEN Limited. All rights reserved. \u201cPlayStation Family Mark\u201d, \u201cPS5 logo\u201d are registered trademarks or trademarks of Sony Interactive Entertainment Inc. PEGI 3. In-game Purchases (Includes Random Items)","legalShort":"\u00a9 2026, XTEN Limited. All rights reserved. PEGI 3. In-game Purchases (Includes Random Items)","parameters":{"pace":"PAC","dribbling":"DRB","shooting":"SHO","defence":"DEF","passing":"PAS","fitness":"FIT","diving":"DIV","reflexes":"RFX","handling":"HAN","speed":"SPD","kicking":"KIC","positioning":"POS"},"roles":{"ST":"ST","LW":"LW","RW":"RW","CAM":"CAM","CM":"CM","CDM":"CDM","LB":"LB","CB":"CB","RB":"RB","GK":"GK"}}}'
+    skeleton-id="svelte-performance-data--281579723"
+ ></tm-player-performance-stage>
+
+ <div class="box" id="svelte-performance-data--281579723">
+    <div class="ssc-square" style="width: 100%; height: 292px; border: 5px solid white;"></div>
+</div>
+
+<div class="box">
+    <h2 class="content-box-headline">Player data </h2>
+    <div class="row collapse">
+        <div class="large-6 large-push-6 columns print">
+                        <div class="weitere-daten-spielerprofil">
+                                    <span class="content-box-subheadline">
+                        Main position                    </span>
+                    <div class="detail-position">
+                        <div class="detail-position__box">
+                                                            <div class="detail-position__inner-box">
+                                    <dl>
+                                        <dt class="detail-position__title">Main position:</dt>
+                                        <dd class="detail-position__position">Defensive Midfield</dd>
+                                                                        </dl>
+                                </div>
+                                <div class="detail-position__position">
+                                    <dl>
+                                        <dt class="detail-position__title">Other position:</dt>
+                                                                                    <dd class="detail-position__position">Central Midfield</dd>
+                                                                                    <dd class="detail-position__position">Right-Back</dd>
+                                                                            </dl>
+                                </div>
+                                                    </div>
+
+
+                        <div class="matchfield__campo">
+                            <div class="matchfield__interior"></div>
+                                                            <div class="position position--primary position--6"></div>
+                                                                   <div class="position position--secondary position--7"></div>
+                               
+                                                                 <div class="position position--secondary position--5"></div>
+                                                        </div>
+                    </div>
+                <div class="box tm-player-market-value-development-container">
+    <tm-market-value-development-graph-integrated
+        mobile="false"
+        translations='{&quot;market value&quot;:&quot;Market value&quot;,&quot;team&quot;:&quot;Club&quot;,&quot;age&quot;:&quot;Age&quot;,&quot;resetZoom&quot;:&quot;Vollansicht&quot;,&quot;current&quot;:&quot;Current Market Value\n\n&quot;,&quot;highest&quot;:&quot;Highest market value&quot;,&quot;thread&quot;:&quot;View market value analysis&quot;,&quot;forum&quot;:&quot;Forum&quot;,&quot;details&quot;:&quot;Market value details&quot;,&quot;headline&quot;:&quot;Market value over time&quot;,&quot;lastChange&quot;:&quot;Last update&quot;}'
+        player-id="636695"
+        thread='{&quot;url&quot;:&quot;&quot;,&quot;thread_title&quot;:&quot;&quot;}'
+        details-url="/marc-casado/marktwertverlauf/spieler/636695">
+    </tm-market-value-development-graph-integrated>
+</div>
+            </div>
+        </div>
+        <div class="large-6 large-pull-6 columns print spielerdatenundfakten">
+            <span class="content-box-subheadline show-for-small">
+                Facts and data            </span>
+            <div class="info-table info-table--right-space ">
+                                    <span class="info-table__content info-table__content--regular">Name in home country:</span>
+                    <span class="info-table__content info-table__content--bold">Marc Casadó Torras</span>
+                                    <span class="info-table__content info-table__content--regular">Date of birth/Age:</span>
+                    <span class="info-table__content info-table__content--bold">
+
+                                                    <a href="/aktuell/waspassiertheute/aktuell/new/datum/2003-09-14">14/09/2003 (22)</a>                        
+                        </span>
+                                    <span class="info-table__content info-table__content--regular">Place of birth:</span>
+                    <span class="info-table__content info-table__content--bold">
+                         <span >Sant Pere de Vilamajor&nbsp;&nbsp;<img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen lazy lazy" /></span>                    </span>
+                                                                                                        <span class="info-table__content info-table__content--regular">Height:</span>
+                    <span class="info-table__content info-table__content--bold">1,72&nbsp;m</span>
+                                    <span class="info-table__content info-table__content--regular">Citizenship:</span>
+                    <span class="info-table__content info-table__content--bold">
+                        <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />&nbsp;&nbsp;Spain                    </span>
+                                <span class="info-table__content info-table__content--regular">Position:</span>
+                <span class="info-table__content info-table__content--bold">
+                    Midfield - Defensive Midfield                </span>
+                                    <span class="info-table__content info-table__content--regular">Foot:</span>
+                    <span class="info-table__content info-table__content--bold">right</span>
+                                                    <span class="info-table__content info-table__content--regular">Player agent:</span>
+                    <span class="info-table__content info-table__content--bold  info-table__content--flex">
+                                                    <a onclick="tmEvent(&quot;spielerprofil&quot;, &quot;click&quot;, &quot;berater-spielerdaten&quot;)" href="/wasserman/beraterfirma/berater/440">Wasserman</a>                                                            <img src="https://tmsi.akamaized.net/berater/verified_premium_minified.png" alt="verified" title="verified" height="13" width="13">
+                                                                        </span>
+                                <span class="info-table__content info-table__content--regular">
+                    Current club:
+                </span>
+                <span class="info-table__content info-table__content--bold info-table__content--flex">
+                    <a href="/fc-barcelona/startseite/verein/131">
+                        <img srcset="https://tmssl.akamaized.net//images/wappen/small/131.png?lm=1406739548 1x,
+                                            https://tmssl.akamaized.net//images/wappen/homepage/131.png?lm=1406739548 2x" alt="FC Barcelona" height="15" width="15" />
+                    </a>
+                    <a title="FC Barcelona" href="/fc-barcelona/startseite/verein/131">FC Barcelona</a>                </span>
+                
+                                            <span class="info-table__content info-table__content--regular">Joined:</span>
+                        <span class="info-table__content info-table__content--bold">
+                            01/07/2024                        </span>
+                        <span class="info-table__content info-table__content--regular">Contract expires:</span>
+                        <span class="info-table__content info-table__content--bold">30/06/2028</span>
+                    
+                                            <span class="info-table__content info-table__content--regular">Last contract extension:</span>
+                        <span class="info-table__content info-table__content--bold">21/06/2024</span>
+                                                        <span class="info-table__content info-table__content--regular">Outfitter:</span>
+                    <span class="info-table__content info-table__content--bold">Under Armour</span>
+                                    <span class="info-table__content info-table__content--regular">Social-Media:</span>
+                    <span class="info-table__content info-table__content--bold">
+<div class="social-media-toolbar__icons">
+            <a href="http://www.instagram.com/marc.casado.6/"
+           target="_blank"
+           title="Instagram"
+           aria-label="Öffnet die Seite von {Instagram} in einem neuen Tab"
+                    >
+
+        <img data-src="https://tmsi.akamaized.net/icons/socialMedia/instagram.svg" class="lazy social" width="15px" height="15px" alt="Social Media Links" />        </a>
+    </div>
+</span>
+                            </div>
+        </div>
+    </div>
+
+
+</div>
+
+<section class="box">
+    <div class="content-box-headline">
+        Transfermarkt Videos    </div>
+    <div class="p10">
+        <tm-consent
+            type="showheroes"
+            no-checkbox
+            embed="PHNjcmlwdCBkYXRhLXdpZD0iYXV0byIgdHlwZT0idGV4dC9qYXZhc2NyaXB0IiBzcmM9Imh0dHBzOi8vY29udGVudC52aXJhbGl6ZS50di9kaXNwbGF5Lz96aWQ9QUFGc20zRHpGdkVlZDZsXyZhbXA7dT1odHRwcyUzQSUyRiUyRnd3dy50cmFuc2Zlcm1hcmt0LmNvbSUyRm1hcmMtY2FzYWRvJTJGcHJvZmlsJTJGc3BpZWxlciUyRjYzNjY5NSI+PC9zY3JpcHQ+"
+        >
+        </tm-consent>
+    </div>
+</section>
+
+        <tm-player-transfer-history
+            player-id="636695"
+            translations='{&quot;headline&quot;:&quot;Transfer history &quot;,&quot;infotext&quot;:&quot;This is the transfer history of Marc Casad\u00f3. The flag next to each club indicates the country of the club&#039;s league.&quot;,&quot;transferHistory&quot;:&quot;Transfer history&quot;,&quot;upcomingTransfers&quot;:&quot;Upcoming transfer&quot;,&quot;feesum&quot;:&quot;Total transfer fees&quot;,&quot;season&quot;:&quot;Season&quot;,&quot;date&quot;:&quot;Date&quot;,&quot;clubFrom&quot;:&quot;Left&quot;,&quot;clubTo&quot;:&quot;Joined&quot;,&quot;marketValue&quot;:&quot;MV&quot;,&quot;transferFee&quot;:&quot;Fee&quot;,&quot;transferMapLinkText&quot;:&quot;Explore the transfer history on a map&quot;,&quot;loan&quot;:&quot;loan transfer&quot;}'>
+        </tm-player-transfer-history>
+        
+<div class="ad-placement-note ad-placement-background werbung werbung-PerformPlayer"  data-ad-placement-note="Advertisement">
+  <div id="d_content_1" style="min-width: 679px; min-height: 382px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_content_1");
+        let has_d_content_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_content_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_content_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_content_1]);
+                has_d_content_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_content_1"));
+      });
+    </script>
+  </div>
+</div>
+
+
+    <div class="box">
+        <h2 class="content-box-headline">
+            Stats of Marc Casadó         </h2>
+
+        
+        <tm-player-performance-table
+            player-id="636695"
+            translations='{"games":"Appearances","goals":"Goals","assists":"Assists","minutesPlayed":"Minutes","detailedStatsLink":"Detailed performance data","cleanSheets":"Clean sheets","goalsConceded":"Goals conceded","minutesPerGoal":"Minutes per goal","sum":"Total ","competition":"Competition"}'
+        ></tm-player-performance-table>
+
+        <a
+            href="/marc-casado/leistungsdaten/spieler/636695"
+            class="content-link">View full stats</a>
+    </div>
+
+    </div>
+    <div class="large-4 columns">
+        <tm-current-rumors player-id="636695"></tm-current-rumors><script type="text/javascript">//RWGzztV("rectangle1")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-rectangle1"  data-ad-placement-note="Advertisement">
+  <div id="d_side_1" style="min-width: 336px; min-height: 280px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_side_1");
+        let has_d_side_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_side_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_side_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_side_1]);
+                has_d_side_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_side_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+
+        <tm-relevant-news type="player" id="636695"></tm-relevant-news>
+
+        
+
+        
+<tm-matches
+    id="636695"
+    type="player"
+    locale="en"
+    translations='{"headline":"Matches","matchDay":"Matchday","postponed":"postponed"}'
+    limit="25">
+</tm-matches>
+
+        
+<tm-player-national-team-career
+    id="636695"
+    translations="{&quot;widgetTitle&quot;:&quot;National team career&quot;,&quot;shirtNumber&quot;:&quot;#&quot;,&quot;nationalteam&quot;:&quot;National team&quot;,&quot;debut&quot;:&quot;Debut&quot;,&quot;matches&quot;:&quot;Matches&quot;,&quot;goals&quot;:&quot;Goals&quot;,&quot;linkTitle&quot;:&quot;Go to national player profile&quot;,&quot;coachAtDebut&quot;:&quot;Coach at debut&quot;,&quot;ageAtDebut&quot;:&quot;Age at debut&quot;}"
+    page-link></tm-player-national-team-career>
+
+        <tm-image-gallery
+            id="636695"
+            type="player"
+            widgetTitle=Gallery            size="small">
+        </tm-image-gallery>
+
+                    <tm-player-compare headline="Compare Marc Casadó with ..." player-id="636695" player-full-name="Marc Casadó" search-player="Search for players" button-text="Compare players"></tm-player-compare>
+
+                <section class="fav-voting">
+        <header class="fav-voting__header">
+            <h2 class="fav-voting__headline">
+                Whom do you prefer?            </h2>
+                            <a href="" class="fav-voting__reload-btn" title="New match" role="button">
+                    <svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <rect width="14" height="15" fill="url(#pattern0)" />
+                        <defs>
+                            <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+                                <use xlink:href="#image0_757_2" transform="scale(0.0714286 0.0666667)" />
+                            </pattern>
+                            <image id="image0_757_2" width="14" height="15" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAPCAYAAADUFP50AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDE0IDc5LjE1Njc5NywgMjAxNC8wOC8yMC0wOTo1MzowMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTQgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjZCMjlCNDlGRTQxNjExRTRCQjAyQUVDQTBFMkY0N0FFIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjZCMjlCNEEwRTQxNjExRTRCQjAyQUVDQTBFMkY0N0FFIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6NkIyOUI0OURFNDE2MTFFNEJCMDJBRUNBMEUyRjQ3QUUiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NkIyOUI0OUVFNDE2MTFFNEJCMDJBRUNBMEUyRjQ3QUUiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz66VzloAAACaUlEQVR42mKULV3MgAwq7VWO33nzxfj1t98s/xkYGAU5mP/KC3A9mXj8gQJMTay+1DcWGKfHWyd96/Xn07uP3GP88/cfslnMQCxvLS/031pO8OLJJx/0ll1+zgjW2OmhVTPn9MPmG68+Q1QyMTLICnCB6ddffjJ8+vGb4ejDdwxATfogQ0V5OBgYNx+9JLTo7KO3Jx6/B2vSkeBjcJAXfC4ryD2PlZnpGlCh+srLz+rOPv0Ad4IkHycDy/UXHy7DNOlL8jPEG8sGF225sg7E7/fRsb/x8tOMx59+oIQD0O8MLBdefJYCcQS42BgCNcW3wjSBwIO3XxatvfGK9xeqnxnef/vFwPLw408wR0OYm6Fh3y0fZAXywjyFVfYqRj9//1V5/fWH7duvv4SffP7F/v3PX7AfJbI2XHzBQAKYFqAvwRg0cfN/ThZmBhletp/C3GxvRbk5DrOzMt9hZWE6h+xsELCQFfwPCg85QW4GlksvPjP8BFoNBOxALMXJxhLOxszEkGAg9QjIh2tscFLbMuHEA4gX+NkZmASBgYIMeNlZGII1xD4rCPPEwcT6fHSC1l9/6f0BGCggYCDB+4yFEc39snwcDBrifP3//zNIAxNGy+P3X5PmnXkkeeXFJ5hzGTQlBHRZ/vz7DxZgAToPlCpAEX377dc6UR52hr9AuccfvoFpcMiL8TIEakvWAgPzHcu7bz8Z7BWF/5vLCFw6+ui9PihpgZIYCMMAyFBbecH/3pqSmSVbr8wEiTFWLdn7bfHFZ1wwRfmWCg8efvgm8/7HX2agN/6LcrH+URHhOdt+8I4lspcAAgwAHaQA7YXnQ28AAAAASUVORK5CYII=" />
+                        </defs>
+                    </svg>
+                </a>
+                        </header>
+        <div class="fav-voting__content">
+                            <p class="fav-voting__question fav-voting__question--text-favorite">
+                    Which player do you prefer...                </p>
+                            <div class="fav-voting__wrapper">
+                <a href="/beliebtheit/speichernSpieler?spieler_id_gewinner=636695&spieler_id_verlierer=38253&kontinent=0&land=0&wettbewerb=ES1&verein=131&position=0&marktwert=0&spieler_id_1=636695&lieblingsverein=0" class="fav-voting__link-player fav-voting__link-player--red">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://img.a.transfermarkt.technology/portrait/medium/636695-1729771427.jpg?lm=1" title="Marc Casadó - source: IMAGO" alt="Marc Casadó" class="lazy" />                    <div class="fav-voting__name">
+                        Marc Casadó                    </div>
+                    <div class="fav-voting__club fav-voting__club--left">
+                        <img src="https://tmssl.akamaized.net//images/wappen/kaderquad/131.png?lm=1406739548" title="FC Barcelona" alt="FC Barcelona" class="" />                    </div>
+                </a>
+                <img src="https://tmssl.akamaized.net//images/beliebtheit/versus.png" alt="versus" class="fav-voting__versus-image" width="39" height="35" />
+                <a href="/beliebtheit/speichernSpieler?spieler_id_gewinner=38253&spieler_id_verlierer=636695&kontinent=0&land=0&wettbewerb=ES1&verein=131&position=0&marktwert=0&spieler_id_1=636695&lieblingsverein=0" class="fav-voting__link-player fav-voting__link-player--black">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://img.a.transfermarkt.technology/portrait/medium/38253-1760445524.jpg?lm=1" title="Robert Lewandowski - source: IMAGO" alt="Robert Lewandowski" class="lazy" />                    <div class="fav-voting__name">
+                        Robert Lewandowski                    </div>
+                    <div class="fav-voting__club fav-voting__club--right">
+                        <img src="https://tmssl.akamaized.net//images/wappen/kaderquad/131.png?lm=1406739548" title="FC Barcelona" alt="FC Barcelona" class="" />                    </div>
+                </a>
+            </div>
+        </div>
+    </section>
+    <script type="text/javascript">//RWGzztV("rectangle2")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-rectangle2"  data-ad-placement-note="Advertisement">
+  <div id="d_side_2" style="min-width: 336px; min-height: 280px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_side_2");
+        let has_d_side_2_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_side_2_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_side_2", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_side_2]);
+                has_d_side_2_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_side_2"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+    </div>
+</div>
+    <div class="row">
+        <div class="large-12 columns">
+            <div id="recommender" class="box" >
+    <div class="OUTBRAIN" data-src="" data-widget-id="AR_1" data-ob-template="DE_Transfermarkt.de" ></div>
+    <tm-consent 
+        no-checkbox 
+        type="outbrain" 
+        embed="PHNjcmlwdCB0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiIGFzeW5jPSJhc3luYyIgc3JjPSIvL3dpZGdldHMub3V0YnJhaW4uY29tL291dGJyYWluLmpzIj48L3NjcmlwdD4=">
+    </tm-consent>
+</div>
+        </div>
+    </div>
+
+<div class="ad-placement-note ad-placement-background werbung werbung-fullsize_contentad"  data-ad-placement-note="Advertisement">
+  <div id="d_bottom_1" style="min-width: 1024px; min-height: 250px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_bottom_1");
+        let has_d_bottom_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_bottom_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_bottom_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_bottom_1]);
+                has_d_bottom_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_bottom_1"));
+      });
+    </script>
+  </div>
+</div>
+
+
+        </main>
+        <footer class="tm-footer">
+               <section class="tm-footer__section-quick-links">
+        <strong class="tm-footer__headline tm-footer__headline--large">
+            Quick Links        </strong>
+        <div class="tm-footer__link-wrapper">
+            <a href="/spieler-statistik/wertvollstespieler/marktwertetop"
+               onclick="tmEvent('footer', 'quick_links', '/spieler-statistik/wertvollstespieler')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Most valuable players in the world            </a>
+            <a href="/statistik/neuestetransfers"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/neuestetransfers')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest transfers            </a>
+            <a href="/geruechte/aktuellegeruechte/statistik"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/aktuellegeruechte')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest rumours            </a>
+            <a href="/spieler-statistik/marktwertaenderungen/marktwertetop"
+                onclick="tmEvent('footer', 'quick_links', '/spieler-statistik/marktwertaenderungen/marktwertetop')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest market value updates            </a>
+            <a href="/statistik/weltrangliste"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/weltrangliste')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                FIFA World ranking            </a>
+                        <a href="/betting/"
+                onclick="tmEvent('footer', 'quick_links', '/betting/')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Betting            </a>
+                    </div>
+    </section>
+                <section class="tm-footer__section-involved">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                Be Involved            </strong>
+            <div class="tm-footer__link-wrapper">
+                <a href="/intern/paten"
+                    onclick="tmEvent('footer', 'be_involved', 'mods_data_scouts')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Mods & Data Scouts                </a>
+                <a href="/profil/bewerbung"
+                    onclick="tmEvent('footer', 'be_involved', 'apply_mod_datascout')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Apply as Mod or Datascout                </a>
+                <a href="/intern/elfGebote"
+                    onclick="tmEvent('footer', 'be_involved', '11_commandments')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    11 commandments                </a>
+                <a href="/intern/fehlermelden"
+                    onclick="tmEvent('footer', 'be_involved', 'found_mistake')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Found a mistake?                </a>
+            </div>
+        </section>
+        <section class="tm-footer__section-career">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                Career            </strong>
+            <div class="tm-footer__link-wrapper">
+                                <a href="/intern/tmteam"
+                   class="tm-footer__link tm-footer__link--arrow"
+                   onclick="tmEvent('footer', 'career', 'contact')"
+                >
+                    Contact                </a>
+            </div>
+        </section>
+        <section class="tm-footer__section-about">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                About Us            </strong>
+            <div class="tm-footer__link-wrapper">
+                <a href="/intern/tmteam"
+                   onclick="tmEvent('footer', 'about_us', 'tm_team')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    TM-Team                </a>
+                <a href="/intern/faq"
+                   onclick="tmEvent('footer', 'about_us', 'faq')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    FAQ                </a>
+            </div>
+        </section>
+            <section class="tm-footer__section-social">
+        <strong class="tm-footer__headline
+            ">
+            Social media        </strong>
+        <div class="tm-footer__social-wrapper">
+                        <a href="https://www.instagram.com/transfermarkt_official/"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'instagram')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/instaRebrush.svg"
+                         alt="instagram"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.facebook.com/transfermarkt.global"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'facebook')">
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/fbRebrush.svg"
+                         alt="facebook"
+                         width="25"
+                         height="25"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.whatsapp.com/channel/0029Va6Kevx47XeF0gE99J35"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'whatsapp')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/whatsappRebrush.svg"
+                         alt="whatsapp"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://twitter.com/TMuk_news"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'x')">
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/twitter_rebrush.svg"
+                         alt="x"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.threads.net/@transfermarkt_official"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'threads')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/threadsRebrush.svg"
+                         alt="threads"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.tiktok.com/@transfermarkt"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'tiktok')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/tiktokRebrush.svg"
+                         alt="tiktok"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.youtube.com/@TransfermarktEnglish"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'youtube')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/RebrushYoutube.svg"
+                         alt="youtube"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://t.me/transfermarkt_off"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'telegram')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/telegramRebrush.svg"
+                         alt="telegram"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                        </div>
+    </section>
+                </footer>
+                <div id="menue_overlay"></div>
+    </div>
+    <section class="tm-footer__mobile tm-footer__transfermarkt-info">
+        <section class="tm-footer__section-desktop-width">
+                            <section class="tm-footer__section-company-links">
+                    <span class="tm-footer__headline tm-footer__headline--medium">
+                        Transfermarkt Company Projects                    </span>
+                    <div class="tm-footer__project-wrapper">
+                        <a href="/wahretabelle"
+                           onclick="tmEvent('footer', 'projects', 'wahretabelle')"
+                           class="tm-footer__link"
+                        >
+                            Wahretabelle                        </a>
+                        <a href="https://www.soccerdonna.de/"
+                           onclick="tmEvent('footer', 'projects', 'soccerdonna')"
+                           class="tm-footer__link"
+                        >
+                            Soccerdonna.de                        </a>
+                        <a href="https://scoutastic.com/de/"
+                           onclick="tmEvent('footer', 'projects', 'scoutastic')"
+                           class="tm-footer__link"
+                        >
+                            Scoutastic.com                        </a>
+                    </div>
+                </section>
+                        <section class="tm-footer__section-company-infos">
+                <span class="tm-footer__headline tm-footer__headline--medium">&copy; Transfermarkt <span id="currentYear">2026</span></span>
+                <div class="tm-footer__company-wrapper">
+                    <a
+                    href="/intern/impressum"
+                    class="tm-footer__link tm-footer__link--blue"
+                    onclick="tmEvent('footer', 'officials', 'impressum')"
+                    >
+                        Legal notice                    </a>
+                    <a
+                        href="/intern/web/datenschutz"
+                        class="tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'data_protection')"
+                        >
+                        Data protection                    </a>
+                    <a
+                        href="javascript:void(0)"
+                        class="cmp-link tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'privacy')"
+                    >
+                        Privacy                    </a>
+                    <a
+                        href="javascript:void(0)"
+                        class="revoke-tracking tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'tracking_revocation')"
+                    >
+                        Revoke Tracking                    </a>
+                    <a
+                        href="/intern/anb"
+                        class="tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'general_conduct_of_use')"
+                        >
+                        Site policy                    </a>
+                                    </div>
+            </section>
+        </section>
+    </section>
+    <script type="text/javascript">
+	if(typeof(adet) == "boolean" && adet == false){
+		img_src="/static/singlepictures/jk99hhfsdh209nbnkjldgh90sghfsdlk";
+	} else {
+		img_src="/static/singlepictures/jku90whjlkjbwbta1g4b8h89fh8sgh8d";
+	}
+	var elem = document.createElement("img");
+	document.body.appendChild(elem);
+	elem.src = img_src;
+</script>
+
+            <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                var cnt = document.querySelectorAll('div.large-4.columns').length;
+                if (cnt == 1) {
+                    var sidebarDiv = document.querySelector('div.large-4.columns');
+                    if (sidebarDiv !== null) {
+                        var sidebar = document.getElementById('werbung_recommender_sidebar_wrapper');
+                        sidebarDiv.appendChild(sidebar);
+                        sidebar.style.display = 'block';
+                    }
+                }
+            });
+        </script>
+        <div id="werbung_recommender_sidebar_wrapper" style="display: none;">
+                    </div>
+    <tm-consent type="adition" no-checkbox embed="PHNjcmlwdCBzcmM9Imh0dHBzOi8vY3JlYXRpdmUtY2RuLm9kZHNzZXJ2ZS5jb20vbG9hZGVyLmpzP3B1Ymxpc2hlcj10bSIgYXN5bmM9ImFzeW5jIj48L3NjcmlwdD4="></tm-consent><tm-consent type='adrenalead' no-checkbox embed='PHNjcmlwdCB0eXBlPSd0ZXh0L2phdmFzY3JpcHQnPgogICAgICAgICAgICB3aW5kb3cuX25BZHpxPXdpbmRvdy5fbkFkenF8fFtdOyhmdW5jdGlvbigpewogICAgICAgICAgICB3aW5kb3cuX25BZHpxLnB1c2goWydzZXRJZHMnLCdkNWE0YzFhNzU4Njc4YTUxJ10pOwogICAgICAgICAgICB2YXIgZT0naHR0cHM6Ly9ub3RpZnB1c2guY29tL3NjcmlwdHMvJzsKICAgICAgICAgICAgdmFyIHQ9ZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7CiAgICAgICAgICAgIHQudHlwZT0ndGV4dC9qYXZhc2NyaXB0JzsKICAgICAgICAgICAgdC5kZWZlcj10cnVlOwogICAgICAgICAgICB0LmFzeW5jPXRydWU7CiAgICAgICAgICAgIHQuc3JjPWUrJ25hZHotc2RrLmpzJzsKICAgICAgICAgICAgdmFyIHM9ZG9jdW1lbnQuZ2V0RWxlbWVudHNCeVRhZ05hbWUoJ3NjcmlwdCcpWzBdOwogICAgICAgICAgICBzLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKHQscyl9KSgpOwogICAgICAgIDwvc2NyaXB0Pg=='></tm-consent>    
+        <tm-modal id="tm-modal-revoke-tracking" additionalClose="Close">
+        <div class="tm-modal__headline">Revoke Tracking</div>
+        <p class="tm-modal__text">Sie haben erfolgreich Ihre Einwilligung in die Nutzung von Transfermarkt mit Tracking und Cookies widerrufen. Sie können sich jetzt zwischen dem Contentpass-Abo und der Nutzung mit personalisierter Werbung, Cookies und Tracking entscheiden.</p>
+    </tm-modal>
+
+<tm-consent type="pubmatic" no-checkbox embed="PHNjcmlwdCB0eXBlPSd0ZXh0L2phdmFzY3JpcHQnPgogICAgICAgICAgICAgICAgICAgICAgICB2YXIgUFdUPXt9OwogICAgICAgICAgICAgICAgICAgICAgICB2YXIgZ29vZ2xldGFnID0gZ29vZ2xldGFnIHx8IHt9OwogICAgICAgICAgICAgICAgICAgICAgICBnb29nbGV0YWcuY21kID0gZ29vZ2xldGFnLmNtZCB8fCBbXTsKICAgICAgICAgICAgICAgICAgICAgICAgdmFyIGdwdFJhbiA9IGZhbHNlOwogICAgICAgICAgICAgICAgICAgICAgICBQV1QuanNMb2FkZWQgPSAoKSA9PiB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBsb2FkR1BUKCk7CiAgICAgICAgICAgICAgICAgICAgICAgIH07CiAgICAgICAgICAgICAgICAgICAgICAgIHZhciBsb2FkR1BUID0gZnVuY3Rpb24oKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBpZiAoIWdwdFJhbikgewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdwdFJhbiA9IHRydWU7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIGdhZHMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdzY3JpcHQnKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgdXNlU1NMID0gJ2h0dHBzOicgPT0gZG9jdW1lbnQubG9jYXRpb24ucHJvdG9jb2w7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ2Fkcy5zcmMgPSAodXNlU1NMID8gJ2h0dHBzOicgOiAnaHR0cDonKSArICcvL3NlY3VyZXB1YmFkcy5nLmRvdWJsZWNsaWNrLm5ldC90YWcvanMvZ3B0LmpzJzsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbm9kZSA9IGRvY3VtZW50LmdldEVsZW1lbnRzQnlUYWdOYW1lKCdzY3JpcHQnKVswXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBub2RlLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKGdhZHMsIG5vZGUpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgICAgICB9OwogICAgICAgICAgICAgICAgICAgICAgICAvLyBGYWlsc2FmZSB0byBjYWxsIGdwdAogICAgICAgICAgICAgICAgICAgICAgICBzZXRUaW1lb3V0KGxvYWRHUFQsIDUwMCk7CgogICAgICAgICAgICAgICAgICAgICAgICAoZnVuY3Rpb24oKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgcHVybCA9IHdpbmRvdy5sb2NhdGlvbi5ocmVmOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIHVybCA9ICcvL2Fkcy5wdWJtYXRpYy5jb20vQWRTZXJ2ZXIvanMvcHd0LzE2MzIyOS8xMDEwMyc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgcHJvZmlsZVZlcnNpb25JZCA9ICcnOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgaWYocHVybC5pbmRleE9mKCdwd3R2PScpPjApewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhciByZWdleHAgPSAvcHd0dj0oLio/KSgmfCQpL2c7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbWF0Y2hlcyA9IHJlZ2V4cC5leGVjKHB1cmwpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgaWYobWF0Y2hlcy5sZW5ndGggPj0gMiAmJiBtYXRjaGVzWzFdLmxlbmd0aCA+IDApewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb2ZpbGVWZXJzaW9uSWQgPSAnLycrbWF0Y2hlc1sxXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIHd0YWRzID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy5hc3luYyA9IHRydWU7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy50eXBlID0gJ3RleHQvamF2YXNjcmlwdCc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy5zcmMgPSB1cmwrcHJvZmlsZVZlcnNpb25JZCsnL3B3dC5qcyc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbm9kZSA9IGRvY3VtZW50LmdldEVsZW1lbnRzQnlUYWdOYW1lKCdzY3JpcHQnKVswXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG5vZGUucGFyZW50Tm9kZS5pbnNlcnRCZWZvcmUod3RhZHMsIG5vZGUpOwogICAgICAgICAgICAgICAgICAgICAgICB9KSgpOwogICAgICAgICAgICAgICAgICAgIDwvc2NyaXB0PgogICAgICAgICAgICAgICAgICAgIA=="></tm-consent><tm-consent type="googleadvertising" no-checkbox embed="PHNjcmlwdCAgc3JjPSJodHRwczovL3NlY3VyZXB1YmFkcy5nLmRvdWJsZWNsaWNrLm5ldC90YWcvanMvZ3B0LmpzIiBhc3luYz0iYXN5bmMiPjwvc2NyaXB0Pg=="></tm-consent>
+<tm-consent type="googleadvertising" no-checkbox embed="PHNjcmlwdCAgc3JjPSJodHRwczovL2MuYW1hem9uLWFkc3lzdGVtLmNvbS9hYXgyL2Fwc3RhZy5qcyIgYXN5bmM9ImFzeW5jIj48L3NjcmlwdD4="></tm-consent>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/relevant-news/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-compare/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/watchlist/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/subnavigation/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-performance-stage/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/market-value-development-graph-integrated/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-transfer-history/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-performance-table/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/current-rumors/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/matches-slider/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-national-team-career/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/image-gallery/bundle.js"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/custom/vendors.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/domain-switcher/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/quick-select-bar/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/userbox/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/live-match-count/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/domain-note/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/consent/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/modal/bundle.js"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/custom/tm-skyscraper.min.js?lm=1767953048"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+	var loginUrl='/profil/login';
+	var onlyDE = '';
+	var onlyMobile = '';
+	var onlyTablet = '';
+	var getUserID = '';
+
+oddsServe("e4063cff1119f9fa72b2bff43adea786", -1);
+/*]]>*/
+</script>
+</body>
+
+</html>

--- a/samples/html/casado_national.html
+++ b/samples/html/casado_national.html
@@ -1,0 +1,1820 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    
+<script type="text/javascript" data-description="sourcepoint stub code">
+    !function () { var e = function () { var e, t = "__tcfapiLocator", a = [], n = window; for (; n;) { try { if (n.frames[t]) { e = n; break } } catch (e) { } if (n === window.top) break; n = n.parent } e || (!function e() { var a = n.document, r = !!n.frames[t]; if (!r) if (a.body) { var i = a.createElement("iframe"); i.style.cssText = "display:none", i.name = t, a.body.appendChild(i) } else setTimeout(e, 5); return !r }(), n.__tcfapi = function () { for (var e, t = arguments.length, n = new Array(t), r = 0; r < t; r++)n[r] = arguments[r]; if (!n.length) return a; if ("setGdprApplies" === n[0]) n.length > 3 && 2 === parseInt(n[1], 10) && "boolean" == typeof n[3] && (e = n[3], "function" == typeof n[2] && n[2]("set", !0)); else if ("ping" === n[0]) { var i = { gdprApplies: e, cmpLoaded: !1, cmpStatus: "stub" }; "function" == typeof n[2] && n[2](i) } else a.push(n) }, n.addEventListener("message", (function (e) { var t = "string" == typeof e.data, a = {}; try { a = t ? JSON.parse(e.data) : e.data } catch (e) { } var n = a.__tcfapiCall; n && window.__tcfapi(n.command, n.version, (function (a, r) { var i = { __tcfapiReturn: { returnValue: a, success: r, callId: n.callId } }; t && (i = JSON.stringify(i)), e.source.postMessage(i, "*") }), n.parameter) }), !1)) }; "undefined" != typeof module ? module.exports = e : e() }();
+</script>
+<script data-description="sourcepoint configuration">
+window._sp_ = {
+    config: {"accountId":1254,"propertyId":7427,"gdpr":{"consentLanguage":"en","targetingParams":{"acps":"false"}},"baseEndpoint":"https://cdn.privacy-mgmt.com","isSPA":true,"cpPropertyId":"7a84b340"}}
+</script>
+<script src="https://cdn.privacy-mgmt.com/wrapperMessagingWithoutDetection.js" async></script>
+<script type="text/javascript" data-description="contentpass integration">
+    (function() {
+        var cpBaseUrl = 'https://cp.transfermarkt.com';
+        var cpController = cpBaseUrl + '/now.js';
+        var cpPropertyId = '7a84b340';
+
+        !function(C,o,n,t,P,a,s){C['CPObject']=n;C[n]||(C[n]=function(){
+        (C[n].q=C[n].q||[]).push(arguments)});C[n].l=+new Date;a=o.createElement(t);
+        s=o.getElementsByTagName(t)[0];a.src=P;s.parentNode.insertBefore(a,s)}
+        (window,document,'cp','script',cpController);
+
+        !function(C,o,n,t,P){if(!C[n].patched){cp('extension','authenticate');P=C[n].q.push;
+        C[n].q.push=function(a){if(a[0]==='authenticate'){if((o['cookie']||'').indexOf('_cpauthhint=')===-1&&
+        !(C['localStorage']||{})['_cpuser']&&C.location.href.toLowerCase().indexOf('cpauthenticated')===-1){
+        t={isLoggedIn:function(){return false;},hasValidSubscription:function(){return false;}};
+        (typeof a[1]==='function'&&a[1](null,t));C[n].afp=true;P.apply(C[n].q,[['authenticate',null]]);
+        return t;}}P.apply(C[n].q,[a]);}}}
+        (window,document,'cp',false);
+
+        cp('create', cpPropertyId, {
+        baseUrl: cpBaseUrl
+        });
+
+        cp('render', {
+        onFullConsent: function() {
+            console.log('[DEMO] onFullConsent');
+        }
+        })
+    })()
+</script>
+
+<script type="text/javascript" data-description="contentpass sourcepoint fast path">
+(function () {
+    cp('authenticate', function(err, user) {
+        if (err || (!user.isLoggedIn() && !user.hasValidSubscription())) {
+        // console.log('[SPCP] Taking fast path');
+        (function spExecMsg() {
+            if (window._sp_ && window._sp_.executeMessaging) {
+            if (!window._sp_.config.isSPA) {
+                // console.warn('[SPCP] Sourcepoint not in SPA mode!');
+            } else if (window._sp_.version) {
+                // console.log('[SPCP] Sourcepoint already running');
+            } else {
+                // console.log('[SPCP] Starting Sourcepoint');
+                window._sp_.executeMessaging();
+            }
+            } else {
+            // console.log('[SPCP] Sourcepoint not loaded yet. Retrying.');
+            setTimeout(spExecMsg, 10);
+            }
+        })();
+        }
+    });
+    })();
+</script>
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="shortcut icon" sizes="192x192" href="/android-chrome-192x192.png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=no" />
+<meta name="keywords" content="Marc Casadó,FC Barcelona,LaLiga,Spain" />
+<meta name="description" content="This is the national team page of FC Barcelona player Marc Casadó. This page contains a statistic about the player&#039;s national team career." />
+<meta property="og:type" content="article" />
+<meta property="og:image" content="https://img.a.transfermarkt.technology/portrait/big/636695-1729771427.jpg?lm=1" />
+<meta property="og:description" content="" />
+<meta property="twitter:image" content="https://img.a.transfermarkt.technology/portrait/big/636695-1729771427.jpg?lm=1" />
+<meta property="og:title" content="Marc Casadó - National team" />
+<meta property="twitter:title" content="Marc Casadó - National team" />
+<meta property="og:url" content="https://www.transfermarkt.com/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="de" rel="alternate" href="https://www.transfermarkt.de/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="de-LU" rel="alternate" href="https://www.transfermarkt.de/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="de-AT" rel="alternate" href="https://www.transfermarkt.at/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="de-CH" rel="alternate" href="https://www.transfermarkt.ch/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="tr" rel="alternate" href="https://www.transfermarkt.com.tr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="it-CH" rel="alternate" href="https://www.transfermarkt.it/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="it" rel="alternate" href="https://www.transfermarkt.it/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="pl" rel="alternate" href="https://www.transfermarkt.pl/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="en-GB" rel="alternate" href="https://www.transfermarkt.co.uk/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="en-IE" rel="alternate" href="https://www.transfermarkt.co.uk/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es" rel="alternate" href="https://www.transfermarkt.es/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-ES" rel="alternate" href="https://www.transfermarkt.es/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-CL" rel="alternate" href="https://www.transfermarkt.es/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-VE" rel="alternate" href="https://www.transfermarkt.es/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-EC" rel="alternate" href="https://www.transfermarkt.es/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-CU" rel="alternate" href="https://www.transfermarkt.es/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="nl" rel="alternate" href="https://www.transfermarkt.nl/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="pt" rel="alternate" href="https://www.transfermarkt.pt/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="ru" rel="alternate" href="https://www.transfermarkt.world/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="fr-CH" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="fr" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="fr-CA" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="fr-CI" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="fr-LU" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="fr-BE" rel="alternate" href="https://www.transfermarkt.fr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="pt-BR" rel="alternate" href="https://www.transfermarkt.com.br/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="en-US" rel="alternate" href="https://www.transfermarkt.us/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="en-CA" rel="alternate" href="https://www.transfermarkt.us/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="en-IN" rel="alternate" href="https://www.transfermarkt.co.in/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="en-ZA" rel="alternate" href="https://www.transfermarkt.co.za/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="x-default" rel="alternate" href="https://www.transfermarkt.com/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="en" rel="alternate" href="https://www.transfermarkt.com/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="nl-BE" rel="alternate" href="https://www.transfermarkt.be/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="ro" rel="alternate" href="https://www.transfermarkt.ro/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="el-GR" rel="alternate" href="https://www.transfermarkt.gr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="ko-KR" rel="alternate" href="https://www.transfermarkt.co.kr/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-AR" rel="alternate" href="https://www.transfermarkt.com.ar/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-MX" rel="alternate" href="https://www.transfermarkt.mx/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-CO" rel="alternate" href="https://www.transfermarkt.co/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="es-PE" rel="alternate" href="https://www.transfermarkt.pe/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="ms" rel="alternate" href="https://www.transfermarkt.my/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="ja" rel="alternate" href="https://www.transfermarkt.jp/marc-casado/nationalmannschaft/spieler/636695" />
+<link hreflang="id" rel="alternate" href="https://www.transfermarkt.co.id/marc-casado/nationalmannschaft/spieler/636695" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-main.min.css?lm=1767953967" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/stylesheets/main_desktop.css?lm=1767953048" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-discover.min.css?lm=1767953967" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-button-list.min.css?lm=1767953967" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-link-list.min.css?lm=1767953967" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-print.min.css?lm=1767953967" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-chosen.min.css?lm=1767953967" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/stylesheets/main.css?lm=1767953048" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-player-profile.min.css?lm=1767953967" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/jquery-ui-custom.css?lm=1767953048" />
+<style type="text/css">
+/*<![CDATA[*/
+
+                .ad-placement-background {
+                    background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxODk2IDgwNyI+CiAgPHBhdGggZD0iTTEwNTYuMyA1MzIuNGMwLTE3LjEtMTUuMy0yOS4yLTMyLTMzLjktMTEuNS0zLjItNjUuNi0xMC42LTExNi45IDAtMTQuNiAzLTYxLjUgMTkuNy02MC43IDM4LjQuNSAxMC42IDE4LjQgMTEuOSAyNS43IDExLjkgMzguNyAwIDQ5LjEtMjIuNyA4Mi42LTIyLjdzMjcuMi0xLjQgMjcuMiAxNC44LTMzLjMgMjEuNS0zNy4yIDIyYy0xNy40IDIuNC04NC42IDEyLjQtMTA4LjYgMjUuMy0zNi40IDE5LjUtNDcgNDAuNi00NyA1Mi42IDAgMzcuNyA1MC43IDQwLjYgNzEuNyA0MC42IDMxLjQgMCA0NS42LTEwLjkgNzEuNy0xMC45czMyLjYgNi41IDQyIDYuOWM3LjMuMyAxMy45LTEuNCAxOS45LTMuMyAxNy4yLTUuNSAxOC4yLTIzLjEgMjMuMy0zNC42IDExLjEtMjUuNSAyMS42LTUxLjMgMzEuMS03Ny4yIDMuNC05LjkgNy4zLTE5LjggNy4zLTI5LjlabS0xNDQuOCAxMDljLTYuNyAxLjUtOS44IDIuMS0xNy40IDIuNC04LjUuMy0yNi43LTMuNS0yNi43LTE1LjMgMC0yNC40IDYzLjUtMzMuMiA3Mi43LTMzLjIgMTEuMi0uNCAxOC4zIDIuNyAxOC4zIDkuOSAwIDIwLjgtNDQuNiAzNS43LTQ2LjkgMzYuMlpNNzkzLjkgNTA3LjVjLTQ0LjctMjcuOS0xMDcuMiA1LTEzMC41IDUtMzEuOCAwLTMwLjctMTIuOC02NC44LTE1LTY5LTQuMS05MCAxMi4yLTEwNS4yIDEyLjJzLTkuMy04LjMtMjEuNS02LjdjLTEzLjMgMi4yLTE1LjUgNS0xOS4xIDEwLTQuNSA2LjMtNTMuNSAxMzguOC01Ni41IDE0Ni4xLTExLjEgMjYuMyA1NS43IDI5LjUgNzAuOCA4LjcgMzkuNy01NC45IDMwLjktMTE0LjIgODAuOS0xMjMuOSAxMS44LTIuMyAyMi4zLTIuNiAzMC40IDkuMWwuNC44YzcuMiAxMy4zLTUuNCAzOS44LTEzLjggNjAuNS00LjEgMTAtMTYuNiA0Mi43LTE1LjUgNTQgMS45IDIxLjEgNjYuOCAxNC4xIDc1LjYtMi4xIDE5LjMtMzUuNiAyMy4xLTk2LjkgNDQuMS0xMTMuNCAyNS42LTIwIDQ5LjItNC43IDUxLjMgNC41IDQuMiAxOC4yLTEzLjUgNTIuNy0yMyA3Mi44LTEzLjQgMjguNS03LjMgNTEuMSAyNyA1MS4yIDExLjQgMCAyNy00LjQgMzMuNy0xNC4xIDUuNy04LjMgMTQuNS0zMS42IDI3LjQtNjYuNSAxNC4xLTM4LjEgMjkuMi04MCA4LjMtOTMuMVpNMTIzNSA1MTQuMmMtMS40LTExLTEyLTE1LjYtMjEuMS0xNS4yLTYuNC4yLTE4LjggNS4yLTI4LjYgNS4yLTEwLjcgMC0xNS4yLTIuMS0yOS43LTQuNy0xNy41LTMuMi0zMy4yLTIuNi00My43IDAtMTYuMiA0LTI4LjcgMjAtMzIuMSAzMi44LTUuOCAyMS0xNi42IDQyLjQtMjQuNyA2My4zLTguNyAyMi41LTIzLjcgNjIuMi0yNC40IDcwLjEtLjYgNi45IDcuMiAxNS43IDE1LjIgMTUuNyAwIDAgMzEgLjMgMzcuMS0uMiAyNS0yLjIgMzQuNi0zNi4yIDQwLjMtNTAuNiA0LjctMTEuNyA5LjUtMjQgMTQuMi0zNS42IDMuMS03LjcgNy4zLTE5LjEgMTYuMS0yNy4zIDE3LjItMTYgMzcuNi0xNiA1Ni4zLTIwLjggMTYuOS00LjQgMjYuOC0xOSAyNS4yLTMyLjZaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTM3LjcgNDEuOXY3MjEuN2gxODA5LjhWNDEuOUgzNy43Wm0xNzg5LjEgNzAxSDU4LjNWNjIuNWgxNzY4LjV2NjgwLjRaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTE2MzIuNCA0OTUuOGMtNy44LTMuMS0xNS4yLTYuMi0xMy42LTE0LjIgMy0xNC41IDQuMy0yNC4zLjctMzAuNC0zLjYtNi0xMi4yLTguMy0yOC45LTcuOC0yNi43LjgtMzYuMiA3LjktNDIgMTcuMS01LjkgOS4xLTguMiAyMC4zLTIwLjQgMjkuMi03LjUgNS40LTE1LjkgNy45LTIzIDExLjItNy4xIDMuMy0xNC44IDguOC0xNC44IDE2LjMuMSA4LjQgNSAxMC45IDEwLjEgMTMuOCA1IDIuOSAxMC4yIDUuMyAxMC43IDEwLjguMyAxNi42LTcuOCAzNS43LTE2IDU0LjYtOC4zIDE4LjgtMTYuNyAzNy4zLTE2LjkgNTIuOC0xLjYgMzYuOSA0Ni43IDMxLjkgNTguMSAzMiAxNi4yLS4yIDU3LjkgMi40IDU4LjYtMjkuOCAwLTktNy43LTEyLTE1LjItMTUuMi03LjUtMy4zLTE0LjgtNi44LTE0LjEtMTYuOS4zLTMuNCA1LjQtMTguNSAxMS0zMy44IDUuNi0xNS4zIDExLjctMzAuNiAxMy45LTM0LjMgNi4yLTEwLjQgMjAuOC0xNS40IDMzLjgtMjAuNCAxMy01IDI0LjQtMTAgMjQuNC0yMC40cy04LjMtMTEuMy0xNi4xLTE0LjVaTTE0MDcuOSA1MDkuNmMtMTMuOCA1LTc3LjUgNDktODguMiAzNC41LTguMy0xNC4xIDMxLjctNzguMyAyNS44LTkwLjgtNy45LTE2LjYtNDQuMi05LTUyLjUtNS0xNS4xIDcuMy0yMC4xIDI0LjgtMjUuNyAzOC44LTEwLjcgMjYuOC02NS42IDE2Ny44LTY4LjkgMTc4LjMtNS42IDE3LjkgNTQuNyAzMCA3NC44LTE2LjcgNi4zLTE0LjUgMjQuNi0zMi4zIDQwLjktMzIuMyAzMS45IDAgMjYuNyA2My43IDcwLjQgNjQuNyA0LjggMCAyMy41LjUgMzYuNy01LjcgMjMuNC0xMS4xLTI4LTc2LjUtMjgtOTYuNnM4Ni44LTU3LjEgNzkuNi02Ny43Yy05LjItMTMuNS00Ny45LTcuNy02NS0xLjVaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTMzMC41IDQxMS43WiIgZmlsbD0iI2I0MTAxZiIvPgogIDxwYXRoIGQ9Ik0xNDI0LjQgMjUyLjZoNDAuM2M0LjIgMCAzMiAwIDMxLjMtMTYuOC0uNi0xMy41LTE4LjctMTcuNS0zMy44LTE3LjYtMTIuOS0uMi01NC4yIDYuNS01NC4yIDIzLjZzNS42IDkuOSAxNi41IDEwLjlaTTU3My40IDI4Mi44Yy05LjIgMC03Mi43IDguOC03Mi43IDMzLjJzMTguMiAxNS43IDI2LjcgMTUuM2M3LjYtLjMgMTAuNy0uOSAxNy40LTIuMyAyLjMtLjUgNDYuOS0xNS40IDQ2LjktMzYuMnMtNy4xLTEwLjMtMTguMy05LjlaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZmlsbD0iI2FmMjAwOSIgZD0iTTM0MC40IDc1NC4xeiIvPgogIDxwYXRoIGQ9Ik0zNzcuMiA3MDYuOGMtNi0yMS42LTI1LjktMzYuMS00OC4zLTM1LjItMy44LjEtNy41LjctMTEuMSAxLjctMjUuNiA3LjItNDAuNiAzMy45LTMzLjQgNTkuNSA2LjEgMjEuNiAyNS45IDM2LjEgNDguMyAzNS4yIDMuOC0uMiA3LjUtLjcgMTEuMS0xLjggMTIuNC0zLjUgMjIuNy0xMS42IDI5LTIyLjggNi4zLTExLjIgNy45LTI0LjIgNC40LTM2LjdabS0xNS40IDMwLjVjLTQuNyA4LjMtMTIuMyAxNC4zLTIxLjQgMTYuOC0yLjcuOC01LjUgMS4yLTguMiAxLjNoLTEuNGMtMTYgMC0yOS45LTEwLjUtMzQuMy0yNi0uOS0zLjItMS4zLTYuNC0xLjMtOS42IDAtMTUuNiAxMC4zLTI5LjkgMjYtMzQuMyAyLjctLjcgNS41LTEuMiA4LjItMS4zaDEuNGMxNS45IDAgMjkuOSAxMC41IDM0LjIgMjYgLjkgMy4yIDEuMyA2LjQgMS4zIDkuNiAwIDYtMS42IDEyLTQuNiAxNy40WiIgZmlsbD0iI2Q3ZDdkNyIvPgogIDxwYXRoIGZpbGw9IiNhZjIwMDkiIGQ9Ik0zMjEuMiA2ODUuNXpNMzMwLjQgMzA4LjV6TTMyMy4yIDMwOS43eiIvPgogIDxwYXRoIGQ9Ik0xODA2LjggODEuOEg3OC4zVjQwNmgxNjZjLTM3LjkgMTYuNS03OC4yIDM0LjEtOTEuOCA0MC0xNC40IDYuMS0yMi4xIDIyLjEtMTcuOSAzNy4yIDMuOCAxMy40IDE2LjEgMjIuOCAzMCAyMi44aDEuMmMyLjQgMCA0LjgtLjUgNy4yLTEuMSAxLS4zIDIuMi0uNiAzLjUtMS4xaC4zYzAtLjEgNjgtMzAuOCA2OC0zMC44bC05LjIgMjIuOEwxOTMuOSA1OThsLS4yLjVjLTIuMiA2LjItMi41IDEyLjgtLjcgMTkgMy44IDEzLjYgMTUuOCAyMi44IDI5LjkgMjIuOGgxLjJjLjcgMCAxLjUgMCAyLjEtLjJsLTM0LjQgODQuN3MtMTMuNyAyOC45IDE0LjUgNDEuMWMzMy4xIDE0LjMgNDMuNi0xOC40IDQzLjYtMTguNGw4MC44LTE5OC44IDQxLjItMTAxLjUgMTQuNCA1LjgtMTQuMiAzNC45LTEgMi43LS4yLjljLTEuMiA1LjEtMS4xIDEwLjUuMyAxNS42IDMuOCAxMy40IDE2LjEgMjIuOCAzMCAyMi44aDEuMWMyIDAgNS0uMyA4LjEtMS40IDEwLjctMy43IDE2LjMtOS4yIDIwLjYtMjAuNWwyNS4zLTYyLjJjMi4yLTUuNCA0LTExLjUgMS43LTE5LjQtMi40LTguNy03LjctMTUuMS0xNS0xOC4xbC0uNC0uMmMtLjUtLjItMS4yLS41LTItLjhsLTMuMi0xLjNoMTM2OS40VjgxLjhaTTM0Mi4zIDE4Ni45YzEwLjUtMi42IDI2LjItMy4yIDQzLjcgMCAxNC41IDIuNiAxOSA0LjcgMjkuNyA0LjcgOS44IDAgMjUuNS00LjggMzEuOS00LjkgOC42LS4xIDIxLjUgMi42IDIxLjUgMTQuM3MtMTUuMSAzMC40LTI5IDMzLjdjLTE4LjggNC42LTM5IDQuMy01Ni4xIDIwLjMtOC44IDguMi0xMyAxOS42LTE2LjEgMjcuMy0zIDcuNS02LjEgMTUuMy05LjIgMjMtNS42LTQuNC0xMi4zLTcuNS0xOS42LTguNy0uNSAwLTEuMS0uMi0xLjctLjNoLS4yYy0uNSAwLTEtLjEtMS41LS4ySDMzMGMtMi42IDAtNS4yLjQtNy43IDEtLjguMi0xLjcuNC0yLjUuNi0xLjQuNC0yLjguOS00LjEgMS40cy0yLjcgMS4xLTMuOSAxLjhjLS42LjMtMS4zLjctMS45IDEtNi44IDMuOS0xMi41IDkuNi0xNi40IDE2LjYtNC4zIDcuNi02LjIgMTYuMi01LjUgMjQuNy4yIDIuOS43IDUuOCAxLjUgOC42LjIuOC41IDEuNS43IDIuMyAwIC4yLjEuMy4yLjUuMi42LjQgMS4yLjcgMS44IDAgLjEuMS4yLjIuNGwuOSAyLjFjMS44IDMuNyA0LjEgNy4yIDYuOCAxMC4yaC0yMi43Yy04IDAtMTUuOC04LjgtMTUuMi0xNS43LjctNy45IDE1LjgtNDcuNSAyNC40LTcwLjEgOC0yMC45IDE4LjktNDIuMyAyNC43LTYzLjMgMy41LTEyLjcgMTUuOS0yOC44IDMyLjEtMzIuOFptMjAuNiAxNTIuOWMwIDEzLjctOSAyNi4zLTIyLjggMzAuMS0yLjQuNy00LjggMS03LjIgMS4xaC0xLjNjLTE0IDAtMjYuMy05LjItMzAuMS0yMi44LS44LTIuOC0xLjItNS42LTEuMi04LjQgMC0xMy43IDktMjYuMyAyMi44LTMwLjEgMi4zLS43IDQuOC0xIDcuMi0xLjFoMS4zYzE0IDAgMjYuMiA5LjMgMzAgMjIuOS44IDIuOCAxLjIgNS42IDEuMiA4LjRabS0xNzUuNCAyOWMtMTEuNC0uMS01OS43IDQuOS01OC4xLTMyIC4yLTE1LjQgOC42LTMzLjkgMTYuOS01Mi44IDguMy0xOC44IDE2LjQtMzcuOSAxNi01NC42LS41LTUuNi01LjctOC0xMC43LTEwLjgtNS0yLjktMTAtNS40LTEwLjEtMTMuOCAwLTcuNSA3LjYtMTMgMTQuNy0xNi4zIDcuMS0zLjMgMTUuNi01LjggMjMtMTEuMiAxMi4zLTguOSAxNC42LTIwLjEgMjAuNC0yOS4yIDUuOS05LjEgMTUuMy0xNi4yIDQyLjEtMTcuMSAxNi44LS41IDI1LjMgMS43IDI4LjkgNy44IDMuNiA2IDIuMyAxNS44LS43IDMwLjQtMS42IDggNS44IDExLjEgMTMuNiAxNC4yIDcuOCAzLjIgMTYuMSA2LjMgMTYuMSAxNC41cy0xMS40IDE1LjUtMjQuNCAyMC40Yy0xMyA1LTI3LjUgOS45LTMzLjggMjAuNC0yLjIgMy43LTguMyAxOS0xMy45IDM0LjMtNS42IDE1LjMtMTAuOCAzMC40LTExIDMzLjgtLjcgMTAuMSA2LjYgMTMuNiAxNC4xIDE2LjkgNy41IDMuMyAxNS4yIDYuMyAxNS4yIDE1LjItLjcgMzIuMi00Mi4zIDI5LjctNTguNiAyOS44Wm0zNiAyNTguOGgtLjhjLTguMyAwLTE1LjYtNS41LTE3LjgtMTMuNi0uNS0xLjctLjctMy4zLS43LTUgMC0yLjEuNC00LjMgMS4xLTYuM3MzNy05MC42IDM3LTkwLjZsMzQuMSAxMy45LTM2LjcgOTAuMmMtMi4yIDUuMi02LjcgOS4xLTEyLjIgMTAuNy0xLjMuNC0yLjQuNy00IC44Wm0xNC40IDExNS4zYy0yLjUgNi4xLTYuNiAxMC40LTEyLjcgMTIuMS0xLjQuNC0yLjkuNi00LjMuN2gtLjhjLTguMyAwLTE1LjEtNS40LTE3LjQtMTMuNC0uNS0xLjctLjctMy40LS43LTUuMSAwLTEuNS4yLTMgLjYtNC41cy4zLTEuMy4zLTEuM2wuNy0yIDgxLjItMTk5LjkgMzQuMSAxMy45LTgxIDE5OS41Wk00MzguNCA0MjBjMi4xLjkgMy44IDIuMyA1IDQuMSAxLjIgMS43IDIuMSAzLjcgMi42IDUuNy40IDEuMy42IDIuNi42IDMuOCAwIDIuMy0uNyA0LjYtMS44IDcuNGwtMjUuNCA2Mi40Yy0xLjQgMy44LTIuOCA2LjUtNC44IDguNi0yIDIuMS00LjYgMy40LTguMSA0LjYtMS41LjUtMyAuNy00LjQuN2gtLjhjLTguNCAwLTE1LjctNS41LTE3LjktMTMuNi0uNS0xLjYtLjctMy4zLS43LTVzLjItMi45LjUtNC4zdi0uMmwuNy0xLjggMTguOC00Ni4zLTM3LjYtMTUuMy00MS4yIDEwMS41LTc1LjctMzAuOC0xLjEtLjUgMjEuMy01Mi42LTk2LjMgNDMuNWMtLjguMy0xLjUuNS0yLjIuNy0xLjQuNC0yLjguNi00LjMuN2gtLjhjLTguMyAwLTE1LjctNS41LTE3LjktMTMuNi0uNS0xLjctLjctMy40LS43LTUgMC03LjMgNC40LTE0LjIgMTEuNC0xNy4yIDI0LjctMTAuNyAxMzUuNS01OSAxNjMuMi03MS4xIDQtMS43IDYuMi0yLjcgNi4zLTIuNyAzLjMtMS40IDYuOC0yLjEgMTAuMi0yLjJoMS4yYzQgMCA3LjIuOCAxMS42IDIuNnM4Ni4zIDM1LjEgODYuMyAzNS4xYy43LjIgMS40LjYgMi4xLjlabTE4OS41LTU4LjRjLTYgMS45LTEyLjYgMy43LTE5LjkgMy4zLTkuNS0uNC0zOS42LTYuOS00Mi02LjktMjYuMSAwLTQwLjMgMTAuOS03MS43IDEwLjlzLTcxLjctMi44LTcxLjctNDAuNiAxMC42LTMzLjEgNDctNTIuNmMyNC0xMi45IDkxLjItMjIuOSAxMDguNi0yNS4zIDMuOS0uNSAzNy4yLTMuMSAzNy4yLTIycy0yMS43LTE0LjktMjcuMi0xNC45Yy0zMy41IDAtNDMuOSAyMi44LTgyLjYgMjIuOHMtMjUuMi0xLjItMjUuNy0xMS45Yy0uOC0xOC42IDQ2LjEtMzUuMyA2MC43LTM4LjMgNTEuMy0xMC42IDEwNS41LTMuMiAxMTYuOSAwIDE2LjcgNC42IDMyIDE2LjggMzIgMzMuOXMtMy45IDIwLTcuMyAyOS45Yy05LjQgMjYtMTkuOSA1MS43LTMxIDc3LjItNS4xIDExLjUtNi4xIDI5LTIzLjMgMzQuNVptMjE2LjYgNy4xYy05LjEgMC0yOS4yIDEuNC0yOS4xLTE0LjcgMC0xMC4zIDM1LjYtODQuNSAzNS42LTEwNC40cy0xNi4yLTIyLjMtMjguMi0yMi4zYy0yOC42IDAtNTEuMSAyMC4yLTYzLjIgNTYuMS02LjcgMjAtMjMuMiA1OS43LTI4IDY2LjktMTAuNSAxNS41LTI3IDE4LjYtNDAuOCAxOC42cy0yOC42LS4yLTI4LjYtMTcuMyAyMy45LTY0LjYgMjcuMy03Mi41YzUuNy0xMy41IDE0LjMtMzcuNiAyMC4xLTUxLjYgMTMuNy0zMy40IDE4LjYtMzguMiA1Mi0zOC43IDEwLjUtLjEgMjguNSA1LjIgNDUgNC44IDIxLjQtLjUgNDYuOS05LjIgNjguNy04LjkgMTUuOC4yIDU4IC43IDU5LjggMzQuMS45IDE2LTI3LjcgNzYuMy0zNC43IDk0LjktMTguMiA0OC40LTE4LjggNTQuOS01NS45IDU0LjlabTE4Ni43LTEzMy42YzEuMSAyNS42IDEyNC41IDguMyAxMTYuMyA2MC42LTE0LjYgOTIuOC0yMjcuNiA4NS45LTIzNi43IDQyLjQtMi4xLTEwLjIgMTguMi0yNiAzNi4zLTI1LjMgMjQuNiAxIDM3LjEgMTcuNiA2My43IDE3LjZzNTEuNS0yLjQgNTMuMS0yMWMuOS0xMC43LTIwLjUtMTQuNi0zNi41LTE2LjMtMTExLjUtMTEuNC03Ny43LTYwLTcwLTY5LjkgNDUuMS01OC4yIDIwOC40LTUwIDIwOC40LTE3LjJzLTI5LjcgMjcuMS00Ni41IDIyLjNjLTI2LjctNy42LTg5LjMtMjAuNS04OC4xIDYuN1ptMjU0LjIgNWMtNi4zIDEwLjEtOS4zIDIyLjEtMTMuNCAzMi42LTguNiAyMi4xLTE4LjggNDMuMi0yNi4xIDY1LjMtOS4xIDI3LjQtMzEgMzEtNDkuNyAzMXMtMzEuNiAwLTMxLjYtMTUuOSA0MC42LTk1IDQwLjYtMTE0LjgtMjIuMy0xNy40LTIyLjMtMjguMyA4LjYtMTQuMiAxNi43LTE3LjhjOS4xLTQgMjIuOS03LjEgMzAuOS0xOC44IDI2LjktMzkuMSA1NC44LTUwLjggOTQuNC01MC44czQ0LjMgMTEuOCA0NC40IDE1LjdjLjcgMjIuOS0zMy43IDI3LjktNDYuNyAzNS44LTEuNiAxLTMuNyAzLjgtMy43IDYuMiAwIDEwLjEgMjIuOCA3LjIgMjIuOCAyMS44cy0zOC4yIDI0LjEtNDEuOSAyNS40Yy01LjIgMi0xMC43IDYuNy0xNC4zIDEyLjRabTEzMy4xIDkxLjdjMzMuMyAwIDU4LjgtMjUuOCA4My44LTI1LjhzMjguMiA0LjQgMjguMiAxNi44LTMwLjEgMjQuNy0zOC45IDI5LjNjLTE5LjMgMTAuMS04Ny44IDI1LjMtMTMzLjggMTAuNS01OS0xOS02NC4yLTU5LjctMzUuMy0xMDcuOSAzMC44LTUxLjMgOTUtNzMuMiAxNTIuOC03My4yczg2LjYgMTEgOTIuMyA1OS45YzEuOCAxNS41LTIgMjkuMi0xNi44IDM3LjYtMTkuOCAxMS4yLTExNi42IDEtMTQ1LjUgNi4xLTExLjEgMi0yNS4xIDYuOS0yNS4xIDIwLjRzMjMuOSAyNi4zIDM4LjMgMjYuM1ptMzExLjgtOTcuNmMtMTguNyA0LjgtMzkuMSA0LjgtNTYuMyAyMC44LTguOCA4LjItMTMgMTkuNi0xNi4xIDI3LjMtNC43IDExLjYtOS41IDIzLjktMTQuMiAzNS42LTUuNyAxNC40LTE1LjMgNDguNC00MC4zIDUwLjYtNiAuNS0zNy4xLjItMzcuMS4yLTggMC0xNS44LTguOC0xNS4yLTE1LjguNy03LjkgMTUuOC00Ny42IDI0LjQtNzAuMSA4LTIwLjkgMTguOS00Mi4zIDI0LjctNjMuMyAzLjUtMTIuNyAxNS45LTI4LjggMzIuMS0zMi44IDEwLjUtMi42IDI2LjItMy4yIDQzLjcgMCAxNC41IDIuNiAxOSA0LjcgMjkuNyA0LjcgOS44IDAgMjIuMi01IDI4LjYtNS4yIDkuMS0uMyAxOS43IDQuMyAyMS4xIDE1LjIgMS43IDEzLjYtOC4zIDI4LjItMjUuMiAzMi42WiIgZmlsbD0iI2Q3ZDdkNyIvPgogIDxwYXRoIGZpbGw9IiNhZjIwMDkiIGQ9Ik0yMjUuMiA3NTV6Ii8+Cjwvc3ZnPgo=);
+                    background-size: 143px 61px;
+                    background-repeat: no-repeat;
+                    background-position: center 20px;
+                }
+/*]]>*/
+</style>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/vendor/jquery.min.js?lm=1767953049"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/assets/b7c5571cf8957553f95f6d9069eaed67/jquery.ba-bbq.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/ads/tisoomi.com.min.js?lm=1767956103"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/jquery-ui-1.10.4.custom.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/main.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/chosen.ajaxaddition.jquery.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/functions.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/main_desktop.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/chosen.jquery.js?lm=1767953048"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+console.info("%c [TM-ADs] Initialize Ads on domain .com (spieler/nationalmannschaft)", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Tisoomi is active -> add Tisoomi script", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot rectangle1 (/58778164/d_side_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format rectangle1", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot rectangle2 (/58778164/d_side_2) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format rectangle2", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot skyscraper (/58778164/d_right_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format skyscraper", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot billboard (/58778164/d_top_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format billboard", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot fullsize_contentad (/58778164/d_bottom_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format fullsize_contentad", "background: #282828; color: #bada55")
+    var oddsServe = function(placement,competition,match,node) {
+        if (!node){
+            var s=document.readyState==='loading'?document.getElementsByTagName('script'):[];
+            node=s.length?s[s.length-1].parentNode:null;
+        }
+        oddsServe.queue.push({contentUnitId:placement,competition:competition,match:match,node:node});
+    }
+    
+    oddsServe.onInit=function(callbacks){
+        if (typeof window.__tcfapi === 'function') {
+            __tcfapi('addEventListener', 2, function(tcdata, success) {
+                let tcf20compatibleString;
+                if(success) {
+                    if (tcdata.eventStatus === 'useractioncomplete') {
+                        tcf20compatibleString = tcdata.tcString;
+                    } else if (tcdata.eventStatus === 'tcloaded') {
+                        tcf20compatibleString = tcdata.tcString;
+                    }
+                    callbacks.setGdprOptions({
+                        gdpr:1,
+                        gdpr_pd:1,
+                        gdpr_consent:tcf20compatibleString,
+                    });
+                }
+            });
+        } else {
+            console.warn('E2: __tcfapi not found');
+        }
+    };
+    oddsServe.options={gdpr_wait:true};
+    oddsServe.queue=[];
+console.info("%c [TM-ADs] Add adslot configuration for rectangle1 | rectangle2 | skyscraper | billboard | fullsize_contentad", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Adslots without configuration: fireplace | skyscraper-left-bound | skyscraperbtf | richmedia | 1by1px", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Register slots with JS vendor lib", "background: #282828; color: #bada55")
+console.warn("%c [TM-ADs] Duplicate placement IDs found: /58778164", "background: #282828; color: #bada55")
+window.addEventListener('load', () => {
+  const offset = window.matchMedia('(max-width: 768px)').matches ? 80 : 120;
+  document.querySelectorAll('[data-sticky]').forEach(node => {
+    const parent = node.parentElement;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) {
+        parent.style.position = 'sticky';
+        parent.style.top = `${offset}px`;
+        parent.style.zIndex = 12000000;
+        setTimeout(() => {
+          parent.style.removeProperty('position');
+          parent.style.removeProperty('top');
+          parent.style.removeProperty('z-index');
+        }, parseInt(node.dataset?.sticky) || 3000);
+        observer.unobserve(parent);
+      }
+    }, { rootMargin: `-${offset}px 0px 0px 0px`, threshold: 1 });
+    observer.observe(parent);
+  });
+});
+PWT = {};
+window.googletag = window.googletag || {cmd: []};
+googletag.cmd.push(() => {
+  window.ad_d_top_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_top_1",
+    [[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90], "fluid"],
+    "d_top_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_side_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_side_1",
+    [[336, 280], [300, 250], [250, 250], "fluid"],
+    "d_side_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_side_2 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_side_2",
+    [[336, 280], [300, 250], [250, 250], "fluid"],
+    "d_side_2"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  window.ad_d_right_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_right_1",
+    [[300, 600], [336, 280], [320, 480], [300, 250], [240, 400], [200, 600], [160, 600], [120, 600]],
+    "d_right_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_bottom_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_bottom_1",
+    [[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90], "fluid"],
+    "d_bottom_1"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  googletag.pubads().setCentering(true);
+  googletag.pubads().disableInitialLoad();
+  googletag.pubads().setTargeting("cg1", ["spieler"]);
+  googletag.pubads().setTargeting("URL", ["www.transfermarkt.com"]);
+  googletag.enableServices();
+});
+!function(t,$,e,s,i,a,o){$[t]||($[t]={init:function(){_("i",arguments)},fetchBids:function(){_("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]});function _(e,s){$[t]._Q.push([e,s])}}("apstag",window,document,"script","//c.amazon-adsystem.com/aax2/apstag.js"),apstag.init({pubID:"5134",adServer:"googletag"});const initAmazonAdBids=(t,$)=>{($&&"tcloaded"===t.eventStatus||"useractioncomplete"===t.eventStatus)&&apstag.fetchBids(
+  {slots:[
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_top_1",
+      slotID:"d_top_1",
+      sizes:[[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_side_1",
+      slotID:"d_side_1",
+      sizes:[[336, 280], [300, 250], [250, 250]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_side_2",
+      slotID:"d_side_2",
+      sizes:[[336, 280], [300, 250], [250, 250]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_right_1",
+      slotID:"d_right_1",
+      sizes:[[300, 600], [336, 280], [320, 480], [300, 250], [240, 400], [200, 600], [160, 600], [120, 600]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_bottom_1",
+      slotID:"d_bottom_1",
+      sizes:[[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90]],
+    },
+  ],
+  timeout:2e3},
+  function(t){googletag.cmd.push(function(){apstag.setDisplayBids()})})};
+"function"==typeof window.__tcfapi&&window.__tcfapi("addEventListener",2,initAmazonAdBids);
+
+document.addEventListener("DOMContentLoaded", () => {
+  const closeButtonSticky = document.getElementById("sticky-ad-close-button");
+  if(closeButtonSticky) {
+    closeButtonSticky.addEventListener("touchstart", function(e) {
+      e.preventDefault();
+      var elem = this.parentNode;
+      elem.parentNode.removeChild(elem);
+    }, {passive: false});
+  }
+});
+
+console.info("%c [TM-ADs] Render ad slots js for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Added external ad script https://securepubads.g.doubleclick.net/tag/js/gpt.js for googleadvertising on wettbewerbe_profile_spieler", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Added external ad script https://c.amazon-adsystem.com/aax2/apstag.js for googleadvertising on wettbewerbe_profile_spieler", "background: #282828; color: #bada55")
+/*]]>*/
+</script>
+<title>Marc Casadó - National team | Transfermarkt</title>
+    <link rel="apple-touch-icon-precomposed" href="/apple-touch-icon-152x152.png">
+    
+<script type="text/javascript">
+   tmData = {
+       loggedIn : "0",
+       tmTraffic: "0",
+   };
+</script>
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+    let utmVars = {
+        eVar1: urlParams.get('utm_campaign'),
+        eVar6: urlParams.get('utm_source'),
+        eVar24: urlParams.get('utm_medium')
+    };
+    Object.keys(utmVars).forEach((k) => utmVars[k] == null && delete utmVars[k]);
+
+    window.tmAnalyticsDataLayer = window.tmAnalyticsDataLayer || [];
+    window.tmAnalytics = {
+        dimensions: {
+            eVar27: 'Marc Casadó (636695)',
+			eVar3: 'FC Barcelona (131)',
+			eVar4: 'LaLiga (ES1)',
+			eVar5: 'Spain',
+			eVar10: 'https://www.transfermarkt.com/marc-casado/nationalmannschaft/spieler/636695',
+			...utmVars,
+            evar19: window.location.href,
+            eVar35 : '',
+			eVar37 : '',
+    },
+    properties: {
+        prop2: 'statistik',
+		prop3: 'spieler',
+		prop4: 'nationalmannschaft',
+		prop5: '636695',
+		prop11: '636695',
+		prop14: 'statistik_spieler_nationalmannschaft_636695',
+		prop9: window.location.hostname,
+        prop10: window.location.href,
+        prop1 : 'false',
+    },
+    pageDetails: {
+        pageViews: {
+            value: 1
+        },
+        isErrorPage: 'false',
+            isHomepage: 'false',
+            name: 'Marc Casadó - National team | Transfermarkt',
+            URL: window.location.href,
+            server: 'web03'
+    },
+    };
+
+function tmEventForLink(category, aTag, label) {
+    const url = new URL(aTag.href);
+    const link = url.pathname + url.search;
+    tmEvent(category, link, label);
+}
+
+function tmEvent(category, action, label, detail = '') {
+    if (typeof gtag === 'function') {
+        gtag('event',
+            action,
+            {
+                'event_category': category,
+                'event_label': label
+            }
+        );
+    }
+
+    const ev = {
+        event: 'tmEvent',
+        tmEvent: {
+            customDimensions: {
+                eVars: {
+                    ...tmAnalytics.dimensions
+                },
+                props: {
+                    prop6: category,
+                    prop7: action,
+                    prop8: label,
+                    prop17: detail,
+                    ...tmAnalytics.properties
+                }
+            },
+            event1to100: {
+                event7: {
+                    value: 1
+                },
+                event8: null,
+            },
+            session: {
+                web: {
+                    webInteraction: {
+                        linkClicks: {
+                            value: 1
+                        }
+                    },
+                    webPageDetails: {
+                        ...tmAnalytics.pageDetails,
+                        ...{
+                            pageViews: {
+                                value: null
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+     if (!window._satellite) {
+        once = false;
+        window._satellite = { _monitors: [{
+            ruleTriggered: (e) => {
+                if (once) {
+                    return;
+                }
+                once = true;
+                setTimeout(() => {
+                    tmAnalyticsDataLayer.push(ev);
+                    tmAnalyticsDataLayer.push(function (dl) {
+                        const state = dl.getState();
+                    });
+                }, 1);
+            }
+        }] };
+    } else {
+        tmAnalyticsDataLayer.push(ev);
+        tmAnalyticsDataLayer.push(function (dl) {
+            const state = dl.getState();
+        });
+    }
+}
+function tmTrackingAndAds() {
+    if (typeof gtag === 'function') {
+        gtag("event", "page_view", {
+            page_path: "/jsContent" + window.location.pathname
+        });
+    }
+
+    tmAnalyticsDataLayer.push({
+        event: 'tmTrackingAndAds',
+        tmTrackingAndAds: {
+            customDimensions: {
+                eVars: tmAnalytics.dimensions,
+                props: tmAnalytics.properties
+            },
+            event1to100: {
+                event7: null,
+                event8: {
+                    value: 1
+                }
+            },
+            session: {
+                web: {
+                    webInteraction: {
+                        linkClicks: {
+                            value: null
+                        }
+                    },
+                    webPageDetails: {
+                        ...tmAnalytics.pageDetails,
+                        ...{
+                            pageViews: {
+                                value: 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+    tmAnalyticsDataLayer.push(function (dl) {
+        const state = dl.getState();
+    });
+}
+function tmTiming(value, name, event_category, event_label) {
+    console.log('tmTiming', value, name, event_category, event_label);
+}
+
+        !function(e,a,n,t){var i=e.head;if(i){
+            if (a) return;
+            var o=e.createElement("style");
+            o.id="alloy-prehiding",o.innerText=n,i.appendChild(o),setTimeout(function(){o.parentNode&&o.parentNode.removeChild(o)},t)}}
+        (document, document.location.href.indexOf("adobe_authoring_enabled") !== -1, ".personalization-container { opacity: 0 !important }", 3000);
+
+            !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
+                []).push(o),n[o]=function(){var u=arguments;return new Promise(
+                function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
+            (window,["alloy"]);
+</script>
+<tm-consent
+    type="adobe"
+    no-checkbox
+    embed="PHNjcmlwdCBhc3luYyBzcmM9Imh0dHBzOi8vYXNzZXRzLmFkb2JlZHRtLmNvbS83Y2FkY2E5NWRkOWEvY2Q0YWI4ODRkMjMxL2xhdW5jaC0wMTI3MmI0MDBjNjUubWluLmpzIj48L3NjcmlwdD4=">
+</tm-consent>
+
+    <script type="text/javascript" src="https://tmssl.akamaized.net//ads/ads.js"></script>
+    <script type="text/javascript">
+        window.tmGaId = "UA-3816204-13";
+
+        function sendIvwData() {}
+    </script>
+            <link rel="canonical" href="https://www.transfermarkt.com/marc-casado/nationalmannschaft/spieler/636695">
+    </head>
+
+<body class="desktop " itemscope itemtype="http://schema.org/WebPage" data-tm-tld="com" data-cmp-layer-id="910164" data-db-name="com-der-zauberzwerg">
+    
+                <tm-domain-note></tm-domain-note>
+        <div id="main">
+                    <button id="back-to-top" title="Nach oben">
+                <svg xmlns="http://www.w3.org/2000/svg" width="17.795" height="10.009" viewBox="0 0 17.795 10.009">
+                    <path id="angle-up" d="M20.683,17.01a1.112,1.112,0,0,1-.786-.326l-7-7-7,7a1.112,1.112,0,1,1-1.573-1.573l7.785-7.785a1.112,1.112,0,0,1,1.573,0l7.785,7.785a1.112,1.112,0,0,1-.786,1.9Z" transform="translate(-4 -7)" fill="#fff"/>
+                </svg>
+            </button>
+            <div class="werbung-skyscraper-left-bound-container">
+                            </div>
+            <div class="werbung-skyscraper-container">
+                <script type="text/javascript">//RWGzztV("skyscraper")</script>
+<div class="ad-placement-note werbung werbung-skyscraper"  data-ad-placement-note="Advertisement">
+  <div id="d_right_1" style="min-height: 600px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_right_1");
+        let has_d_right_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_right_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_right_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_right_1]);
+                has_d_right_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_right_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+            </div>
+
+            <div class="werbung-skyscraperbtf-container">
+                            </div>
+        
+        <div id="tm-overlay"></div>
+
+                    <div class="tm-header__box">
+                <!-- logo  -->
+                <a href="/" class="tm-header__logo" onclick="tmEvent('hauptnavi', '/', 'TM-Logo');">
+                    <img src="https://tmsi.akamaized.net/head/tm_logo_rebrush.svg"
+                         height="62"
+                         width="156"
+                         title="Transfermarkt"
+                         alt="Transfermarkt"
+                    >
+                </a>
+
+                <!-- domainswitcher  -->
+                <div class="domin-swicher">
+                    <tm-domain-switcher
+                        tld="com"
+                        translations='{&quot;chooseYourDomain&quot;:&quot;Choose your domain&quot;}'></tm-domain-switcher>
+                </div>
+
+                <!-- live -->
+                <tm-live-match-count
+                    class="tm-header__live"
+                    auto-request                    content='{&quot;liveMatches&quot;:&quot;Live matches&quot;,&quot;liveMatch&quot;:&quot;Live maches&quot;,&quot;live&quot;:&quot;Live&quot;}'></tm-live-match-count>
+
+                <!-- Search -->
+                                    <div class="tm-header__search " id="schnellsuche-platz">
+                        <form name="schnellsuche" id="schnellsuche" class="tm-header__form" action="/schnellsuche/ergebnis/schnellsuche">
+                            <input type="text" name="query" class="tm-header__input--search-field" onClick="" placeholder="Enter your search term" autocorrect="off" spellcheck="false" value="" />
+                            <button type="submit" value="" class="tm-header__input--search-send" alt="Search">
+                                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="18" viewBox="0 0 18 18">
+                                    <path d="M17.825,16.847 L14.28,13.303 C17.072,9.987 16.756,5.061 13.563,2.13 C10.37,-0.8 5.435,-0.695 2.37,2.37 C-0.695,5.435 -0.8,10.37 2.13,13.563 C5.061,16.756 9.987,17.072 13.303,14.28 L16.847,17.825 C17.121,18.069 17.538,18.057 17.797,17.797 C18.057,17.538 18.069,17.121 17.825,16.847 z M1.418,8.108 C1.417,4.413 4.412,1.417 8.107,1.416 C11.802,1.415 14.798,4.411 14.799,8.106 C14.799,11.801 11.804,14.797 8.108,14.797 C4.414,14.797 1.419,11.803 1.418,8.108 z" fill="#000" />
+                                </svg>
+                            </button>
+                        </form>
+                        <a href="/detailsuche/spielerdetail/suche" title="to detailed player search" id="detailsuche-head" class="tm-header__search-detail">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="18" viewBox="0, 0, 18, 18">
+                                <path d="M3.138,3.558 C3.137,1.593 4.727,0 6.69,0 C8.652,-0 10.243,1.592 10.243,3.556 C10.243,5.521 8.653,7.113 6.69,7.113 C4.729,7.113 3.138,5.522 3.138,3.558 z M8.233,13.187 C8.261,11.778 8.861,10.442 9.893,9.486 C9.967,9.418 9.997,9.315 9.971,9.219 C9.946,9.119 9.863,9.044 9.76,9.03 C9.331,8.938 8.893,8.893 8.454,8.895 L4.906,8.895 C3.583,8.808 2.286,9.298 1.35,10.239 C0.414,11.179 -0.07,12.479 0.021,13.804 C-0.085,14.656 0.209,15.509 0.817,16.114 C1.425,16.72 2.279,17.009 3.13,16.897 L9.266,16.897 C9.372,16.895 9.467,16.831 9.508,16.732 C9.549,16.634 9.527,16.521 9.453,16.444 C8.665,15.544 8.232,14.387 8.236,13.191 z M17.805,17.804 C17.68,17.93 17.511,18 17.334,18 C17.158,18 16.989,17.93 16.864,17.804 L15.237,16.177 C13.686,17.242 11.58,16.949 10.378,15.501 C9.176,14.052 9.274,11.926 10.604,10.594 C11.934,9.263 14.058,9.165 15.505,10.368 C16.952,11.571 17.244,13.68 16.181,15.233 L17.805,16.866 C18.065,17.126 18.065,17.548 17.805,17.808 z M15.484,13.182 C15.484,11.911 14.455,10.881 13.186,10.881 C11.917,10.881 10.888,11.911 10.888,13.182 C10.888,14.452 11.917,15.482 13.186,15.482 C14.455,15.482 15.484,14.452 15.484,13.182 z" fill="#000" />
+                            </svg>
+                        </a>
+                    </div>
+                
+                <!-- login button -->
+                <div class="tm-header__login">
+                    <tm-userbox translations='{&quot;addFavorite&quot;:&quot;Add favourite&quot;,&quot;adminArea&quot;:&quot;Admin area&quot;,&quot;adminTools&quot;:&quot;Admin tools&quot;,&quot;allFavoriteLinkText&quot;:&quot;Go to all my favourite links&quot;,&quot;applyAsModOrDatascout&quot;:&quot;Apply as a moderator or datascout&quot;,&quot;checkAllNews&quot;:&quot;Check all news&quot;,&quot;checkAllRumours&quot;:&quot;Check all rumours&quot;,&quot;chooseYourDomain&quot;:&quot;Choose your domain&quot;,&quot;clickAgain&quot;:&quot;Click again to copy shortlink to your clipboard&quot;,&quot;clubBoard&quot;:&quot;Club forum&quot;,&quot;copied&quot;:&quot;Copied to your clipboard&quot;,&quot;copyLink&quot;:&quot;Link kopieren&quot;,&quot;createAccount&quot;:&quot;Create your account&quot;,&quot;createNewMessage&quot;:&quot;Create a new message&quot;,&quot;createShortlink&quot;:&quot;create a shortlink&quot;,&quot;createShortNews&quot;:&quot;Create memo&quot;,&quot;dashboard&quot;:&quot;Overview&quot;,&quot;dataAdministration&quot;:&quot;Data administration&quot;,&quot;debug&quot;:&quot;Debug&quot;,&quot;deleteAll&quot;:&quot;Delete all&quot;,&quot;deleteConfirm&quot;:&quot;Yes, delete all&quot;,&quot;editText&quot;:&quot;Edit&quot;,&quot;forgotPassword&quot;:&quot;Forgot password?&quot;,&quot;forgotUsername&quot;:&quot;Forgot username?&quot;,&quot;forgotLoginDetails&quot;:&quot;Forgot your login details?&quot;,&quot;forum&quot;:&quot;forum&quot;,&quot;groundhoppingTool&quot;:&quot;Groundhopping Tool&quot;,&quot;lastMatch&quot;:&quot;last match&quot;,&quot;signin&quot;:&quot;Log in&quot;,&quot;login&quot;:&quot;Login&quot;,&quot;logOut&quot;:&quot;Log out&quot;,&quot;manageFavorites&quot;:&quot;Manage favourites&quot;,&quot;marketValue&quot;:&quot;market value&quot;,&quot;matchplan&quot;:&quot;Schedule&quot;,&quot;messages&quot;:&quot;Private messages&quot;,&quot;myClub&quot;:&quot;My club&quot;,&quot;myClubText&quot;:&quot;With a Transfermarkt account you can register your favourite club and find all important information about your club (matches, news, quick links). &quot;,&quot;myDreamTeam&quot;:&quot;My dream team&quot;,&quot;myFavorites&quot;:&quot;My favourites&quot;,&quot;myFavoritesText&quot;:&quot;With a Transfermarkt account, you can save any page as a favourite and then access it with one click.&quot;,&quot;myProfile&quot;:&quot;My profile&quot;,&quot;news&quot;:&quot;News&quot;,&quot;newsAdministration&quot;:&quot;News administration&quot;,&quot;nextMatch&quot;:&quot;next match&quot;,&quot;noNewNotifications&quot;:&quot;No new notifications&quot;,&quot;notifications&quot;:&quot;Notifications&quot;,&quot;notificationsDeletedAutomatically&quot;:&quot;Note: Notifications are automatically deleted after 30 days.&quot;,&quot;notifyDeleteMessage&quot;:&quot;Private messages older than 45 days will be deleted from time to time (except for data scouts and moderators)&quot;,&quot;or&quot;:&quot;or&quot;,&quot;other&quot;:&quot;Miscellaneous&quot;,&quot;overview&quot;:&quot;overview&quot;,&quot;password&quot;:&quot;Password&quot;,&quot;playerRatings&quot;:&quot;Player ratings&quot;,&quot;playerWatchlist&quot;:&quot;Players Watchlist&quot;,&quot;profile&quot;:&quot;Profile&quot;,&quot;progDebug&quot;:&quot;Prog. depanare&quot;,&quot;progProfile&quot;:&quot;Prog. profile&quot;,&quot;registerNow&quot;:&quot;Sign up now&quot;,&quot;rememberMe&quot;:&quot;Remember me&quot;,&quot;removeFavorite&quot;:&quot;Delete favourite&quot;,&quot;rumors&quot;:&quot;Rumours&quot;,&quot;schedule&quot;:&quot;Schedule&quot;,&quot;setting&quot;:&quot;Settings&quot;,&quot;shortlink&quot;:&quot;Shortlink&quot;,&quot;shortLinkCreationError&quot;:&quot;An Error occured creating the shortlink.&quot;,&quot;shortLinkHasBeenCreated&quot;:&quot;Shortlink has been created an was copied to your clipboard&quot;,&quot;shortLinkIsBeingCreated&quot;:&quot;Creating shortlink ...&quot;,&quot;showAllMessages&quot;:&quot;Show all messages&quot;,&quot;totalMarketValue&quot;:&quot;Total market value&quot;,&quot;translation&quot;:&quot;Translation&quot;,&quot;username&quot;:&quot;Username&quot;,&quot;whyRegister&quot;:&quot;Why register?&quot;,&quot;Bitte korrigieren Sie die markierten Felder&quot;:&quot;Bitte korrigieren Sie die markierten Felder&quot;,&quot;mindestensDreiZeichen&quot;:&quot;At least three characters&quot;,&quot;mindestensAchtZeichen&quot;:&quot;At least eight characters&quot;,&quot;pleaseCorrectFields&quot;:&quot;profil&quot;,&quot;minThreeCharacters&quot;:&quot;At least three characters&quot;,&quot;minEightCharacters&quot;:&quot;At least eight characters&quot;,&quot;noAtCharacter&quot;:&quot;The @ character is not allowed in the username&quot;,&quot;agentProfile&quot;:&quot;My Agency Profile&quot;}' page-title="Marc Casadó - National team | Transfermarkt" tld="com" agent-profile=""  />
+                </div>
+            </div>
+        
+        
+                        <!-- mobile end -->
+            <nav class="main-navbar">
+                                    <a href="/" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/', 'DISCOVER')">
+                        DISCOVER                    </a>
+                                    <a href="/navigation/transfersundgeruechte" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/transfersundgeruechte', 'TRANSFERS & RUMOURS')">
+                        TRANSFERS & RUMOURS                    </a>
+                                    <a href="/navigation/marktwerte" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/marktwerte', 'MARKET VALUES')">
+                        MARKET VALUES                    </a>
+                                    <a href="/navigation/wettbewerbe" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/wettbewerbe', 'COMPETITIONS')">
+                        COMPETITIONS                    </a>
+                                    <a href="/navigation/statistiken" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/statistiken', 'STATISTICS')">
+                        STATISTICS                    </a>
+                                    <a href="/navigation/community" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/community', 'COMMUNITY')">
+                        COMMUNITY                    </a>
+                                    <a href="/navigation/gaming" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/gaming', 'GAMING')">
+                        GAMING                    </a>
+                                <div class="main-navbar__details">
+                    <div class="hamburger">
+                        <em></em>
+                    </div>
+                    <div class="dropdown-layer"></div>
+                    <div class="main-navbar__dropdown">
+                                                            <div class="recommendation">
+        
+    
+                            <div class="tm-discover__hero-container tm-discover__hero-container-grid tm-discover-container-grid">
+                    
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--two-thirds  "><span class="tm-discover__h2">Recommendations</span><ul class="tm-button-list"><li><a
+                        href="/uefa-champions-league/startseite/wettbewerb/CL"
+                        title="Champions League"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/uefa-champions-league/startseite/wettbewerb/CL' , '1_1', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/cl.png?lm=1626810555"
+                            alt="UEFA Champions League"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/premier-league/startseite/wettbewerb/GB1"
+                        title="Premier League"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/premier-league/startseite/wettbewerb/GB1' , '1_2', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/gb1.png?lm=1521104656"
+                            alt="Premier League"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/laliga/startseite/wettbewerb/ES1"
+                        title="LaLiga"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/laliga/startseite/wettbewerb/ES1' , '1_3', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/es1.png?lm=1725974302"
+                            alt="LaLiga"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/serie-a/startseite/wettbewerb/IT1"
+                        title="Serie A"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/serie-a/startseite/wettbewerb/IT1' , '1_4', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/it1.png?lm=1656073460"
+                            alt="Serie A"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/bundesliga/startseite/wettbewerb/L1"
+                        title="Bundesliga"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/bundesliga/startseite/wettbewerb/L1' , '1_5', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/l1.png?lm=1525905518"
+                            alt="Bundesliga"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/champions-league/startseite/pokalwettbewerb/CL"
+                        title="UEFA Champions League"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/champions-league/startseite/pokalwettbewerb/CL' , '1_6', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/fr1.png?lm=1732280518"
+                            alt="Ligue 1"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li></ul></section>
+                                                                                
+        
+    
+                
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--one-third  tm-button-list__desktop"><span class="tm-discover__h2">Player agents</span><ul class="tm-button-list"><li><a
+                        href="/agent-support/beraterIndex/berater"
+                        title="Agent support"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/agent-support/beraterIndex/berater' , '2_1', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-support.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>support</a></li><li><a
+                        href="/berater/beraterfirmenuebersicht/berater"
+                        title="Agent statistics"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/berater/beraterfirmenuebersicht/berater' , '2_2', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-statistic.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>statistics</a></li><li><a
+                        href="/premium-service/berater"
+                        title="Premium service"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/premium-service/berater' , '2_3', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/premium-service.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Premium<br>service</a></li></ul></section>
+                                                                                
+        
+    
+                
+                                            
+<section class="tm-link-list-container tm-link-list--full ">
+        <div
+        class="tm-link-list-element"
+        role="navigation"
+        aria-label=""
+    >
+                    
+                        
+                                            <ul
+    class="tm-link-list-unordered   recommendation__links"
+>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/neuestetransfers"
+                    title="Latest transfers"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/neuestetransfers' , '3_1','linkList');"
+                >
+                    Latest transfers
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/rumour-mill/detail/forum/154"
+                    title="Rumour Mill"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/rumour-mill/detail/forum/154' , '3_2','linkList');"
+                >
+                    Rumour Mill
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/aktuell/newsarchiv"
+                    title="All news"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/aktuell/newsarchiv' , '3_3','linkList');"
+                >
+                    All news
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/whatsMyValue"
+                    title="What's my value?"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/whatsMyValue' , '3_4','linkList');"
+                >
+                    What's my value?
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/spieler-statistik/wertvollstespieler/marktwertetop"
+                    title="Most valuable players in the world"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/spieler-statistik/wertvollstespieler/marktwertetop' , '3_5','linkList');"
+                >
+                    Most valuable players in the world
+                </a>
+                    </li>
+    </ul>
+                                            <ul
+    class="tm-link-list-unordered   recommendation__links"
+>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/spieler-statistik/wertvollstemannschaften/marktwertetop"
+                    title="Most valuable clubs in the world"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/spieler-statistik/wertvollstemannschaften/marktwertetop' , '3_6','linkList');"
+                >
+                    Most valuable clubs in the world
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/marktwertanalyse/detail/forum/357"
+                    title="Market value analysis"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/marktwertanalyse/detail/forum/357' , '3_7','linkList');"
+                >
+                    Market value analysis
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/vertragslosespieler"
+                    title="Free agents"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/vertragslosespieler' , '3_8','linkList');"
+                >
+                    Free agents
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/endendevertraege"
+                    title="Contracts ending"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/endendevertraege' , '3_9','linkList');"
+                >
+                    Contracts ending
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/betting/"
+                    title="Betting"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/betting/' , '3_10','linkList');"
+                >
+                    Betting
+                </a>
+                    </li>
+    </ul>
+                        </div>
+
+    </section>
+                                                                        
+        
+    
+                
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--full  tm-button-list__mobile"><span class="tm-discover__h2">Player agents</span><ul class="tm-button-list"><li><a
+                        href="/agent-support/beraterIndex/berater"
+                        title="Agent support"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/agent-support/beraterIndex/berater' , '4_1', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-support.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>support</a></li><li><a
+                        href="/berater/beraterfirmenuebersicht/berater"
+                        title="Agent statistics"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/berater/beraterfirmenuebersicht/berater' , '4_2', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-statistic.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>statistics</a></li><li><a
+                        href="/premium-service/berater"
+                        title="Premium service"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/premium-service/berater' , '4_3', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/premium-service.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Premium<br>service</a></li></ul></section>
+                                                                                
+                    </div>
+        
+    </div>
+                                                </div>
+                </div>
+            </nav>
+
+            <div class="quick-select-wrapper">
+    
+    <tm-quick-select defaultCountry="157" defaultCompetition="ES1" defaultClub="131" defaultPlayer="636695" dropdown-visible="" translations='{"home":"Home","country":"Country","competition":"Competition","club":"Club","player":"Player","attack":"Striker","midfield":"Midfielder","defense":"Defender","goalkeeper":"Goalkeeper"}'>
+    </tm-quick-select>
+</div>
+
+            
+        
+        <script type="text/javascript">//RWGzztV("billboard")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-billboard"  data-ad-placement-note="Advertisement">
+  <div id="d_top_1" style="min-width: 1024px; min-height: 250px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_top_1");
+        let has_d_top_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_top_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_top_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_top_1]);
+                has_d_top_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_top_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+
+
+        
+        <main id="tm-main">
+            
+    <div id="modal-1" class="modal micromodal-slide" aria-hidden="true" tabindex="1">
+        <div class="modal__overlay" tabindex="-1" data-custom-close>
+            <div
+                class="modal__container"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="modal-1-title"
+                data-custom-close
+                >
+                <header class="modal__header">
+                    <button
+                        class="modal__close modal__close--profile-img"
+                        aria-label="Close modal"
+                        data-custom-close
+                        >
+                    </button>
+                </header>
+                <div id="modal-1-content" class="modal__content">
+                                        <img src='https://img.a.transfermarkt.technology/portrait/big/636695-1729771427.jpg?lm=1' alt='Marc Casadó' title='Marc Casadó' data-custom-close loading="lazy">
+                </div>
+            </div>
+        </div>
+    </div>
+
+<header class="data-header" itemscope itemtype="https://schema.org/Person">
+                    <div class="data-header__headline-container">
+            <h1 class="data-header__headline-wrapper">
+                                    <span class="data-header__shirt-number">
+                        #17                    </span>
+                                Marc <strong>Casadó</strong>            </h1>
+                            <tm-watchlist player-id="636695"></tm-watchlist>
+                                </div>
+                    <div class="data-header__badge-container">
+                                                    <a href="/marc-casado/erfolge/spieler/636695" title="Spanish champion" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/11.png?lm=1520606997" title="Spanish champion" alt="Spanish champion" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                    <a href="/marc-casado/erfolge/spieler/636695" title="Spanish cup winner" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/94.png?lm=1520606999" title="Spanish cup winner" alt="Spanish cup winner" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                    <a href="/marc-casado/erfolge/spieler/636695" title="Spanish Super Cup winner" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/93.png?lm=1520606999" title="Spanish Super Cup winner" alt="Spanish Super Cup winner" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                    <a href="/marc-casado/erfolge/spieler/636695" title="Torneio Internacional Algarve U17" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/538.png?lm=1747150597" title="Torneio Internacional Algarve U17" alt="Torneio Internacional Algarve U17" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                                    <a href="/marc-casado/erfolge/spieler/636695"
+                       title="All titles & victories"
+                       class="data-header__success-more"
+                    >
+                    </a>
+                            </div>
+        
+                    <div class="data-header__box--big">
+                                    <a href="/fc-barcelona/startseite/verein/131" class="data-header__box__club-link">
+                                            <img srcset="
+                            https://tmssl.akamaized.net//images/wappen/normquad/131.png?lm=1406739548 1x,
+                            https://tmssl.akamaized.net//images/wappen/homepageWappen150x150/131.png?lm=1406739548 2x
+                            " alt="FC Barcelona" height="100" width="100" />
+                                        </a>
+                                <div class="data-header__club-info">
+                    <span class="data-header__club" itemprop="affiliation">
+                        <a title="FC Barcelona" href="/fc-barcelona/startseite/verein/131">Barcelona</a>                    </span><br />                    
+                                                                            <span class="data-header__league">
+                                    <a class="data-header__league-link" href="/laliga/startseite/wettbewerb/ES1">
+                                        <img src="https://tmssl.akamaized.net//images/logo/verytiny/es1.png?lm=1725974302" title="LaLiga" alt="LaLiga" class="" />LaLiga                                    </a>
+                                </span>
+                                                                            <span class="data-header__label">League level:
+                                <span class="data-header__content">
+                                    <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />First Tier                                </span>
+                            </span>
+                                                                                                        <span class="data-header__label">Joined: <span class="data-header__content">01/07/2024</span></span>
+                            <span class="data-header__label">Contract expires: <span class="data-header__content">30/06/2028</span></span>
+                                                            </div>
+            </div>
+        
+        <div class="data-header__profile-container">
+                            <div class="modal-trigger" data-custom-open="modal-1" id="fotoauswahlOeffnen" style="cursor:pointer" onclick="tmEvent('spielerprofil','click','profilbild');">
+            
+                                <img src="https://img.a.transfermarkt.technology/portrait/header/636695-1729771427.jpg?lm=1" title="Marc Casadó" alt="Marc Casadó" class="data-header__profile-image" height="181" width="139" /><div class="bildquelle"><span title="IMAGO">IMAGO</span></div>
+                                    <span class="modal-trigger-icon">+</span>
+                </div>
+                        </div>
+        <div class="data-header__info-box ">
+            <div class="data-header__details">
+                <ul class="data-header__items">
+                                            <li class="data-header__label">Date of birth/Age:
+                            <span itemprop="birthDate" class="data-header__content">
+                                14/09/2003 (22)                            </span>
+                        </li>
+
+                                                    <li class="data-header__label">Place of birth:
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />                                <span class="data-header__content" itemprop="birthPlace">
+                                    <span class="cp" title="Sant Pere de Vilamajor">Sant Pere de ...</span>                                </span>
+                            </li>
+                        
+                                            <li class="data-header__label">Citizenship:
+                            <span itemprop="nationality" class="data-header__content">
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />                                Spain                            </span>
+                        </li>
+                                    </ul>
+                <ul class="data-header__items">
+                                            <li class="data-header__label">Height:
+                            <span itemprop="height" class="data-header__content">
+                                1,72 m                            </span>
+                        </li>
+                    
+                    <li class="data-header__label">Position:
+                        <span class="data-header__content">
+                            Defensive Midfield                        </span>
+                    </li>
+                    
+                        <li class="data-header__label">Agent:
+                            <span class="data-header__content data-header__content--vertical-aligned">
+                                
+                                    <a onclick="tmEvent(&quot;spielerprofil&quot;, &quot;click&quot;, &quot;berater-header-premium&quot;)" href="/wasserman/beraterfirma/berater/440">Wasserman</a>                                                                            <img class="data-header__verified-logo" src="https://tmsi.akamaized.net/berater/verified_premium_minified.png" alt="verified" title="verified" height="13" width="13">
+                                                                                                </span>
+                        </li>
+
+                                    </ul>
+                <ul class="data-header__items">
+                                            <li for="" class="data-header__label">
+                                                            Former International:
+                                                        <span class="data-header__content">
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen flagge" /><a title="Spain" href="/spanien/startseite/verein/3375">Spain</a>                            </span>
+                        </li>
+                                                    <li class="data-header__label">Caps/Goals:
+                                <a class="data-header__content data-header__content--highlight" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375">2                                </a>/
+                                <a class="data-header__content data-header__content--highlight" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375">0                                </a>
+                            </li>
+                        <li class="data-header__label theme-button">
+    </li>
+                </ul>
+            </div>
+        </div>
+            
+            <div class="data-header__box--small">
+                <a href="/marc-casado/marktwertverlauf/spieler/636695" class="data-header__market-value-wrapper"><span class="waehrung">€</span>25.00<span class="waehrung">m</span>                <p class="data-header__last-update">Last update: 12/12/2025</p></a>
+            </div>
+
+            
+    </header>
+<a href="https://www.transfermarkt.com/transfer-focus-what-do-the-traditional-big-six-clubs-need-this-january-/view/news/431862"
+        target="1"
+    class="db mt10"
+        onclick="tmEvent('banner', 'https://www.transfermarkt.com/transfer-focus-what-do-the-traditional-big-six-clubs-need-this-january-/view/news/431862', 'd-day-banner');"
+>
+    <img
+        loading="lazy"
+        src="https://dzjovqk3zamsg.cloudfront.net/big-six-desktop-banner.jpg"
+        width="1034"
+        height="99"
+        alt="deadline-day banner"
+    >
+</a>
+
+<script type="text/javascript">
+    (() => {
+        const cookies = document.cookie
+            .split(';')
+            .map(c => c.trim().split('='))
+            .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+        const isContentPassUser = cookies?._cpauthhint !== undefined;
+        if (isContentPassUser) {
+            const adNodes = document.querySelectorAll('.ad-placement-note');
+            adNodes.forEach(node => node.remove());
+        }
+    })();
+</script><tm-subnavigation
+    controller="spieler"
+    id="636695"
+    season=""
+    section="spieler"
+    style="display: block; margin: 0 5px;">
+</tm-subnavigation>
+<div class="row">
+            <div class="large-8 columns">
+            
+<tm-player-national-team-career
+    id="636695"
+    translations="{&quot;widgetTitle&quot;:&quot;National team career&quot;,&quot;shirtNumber&quot;:&quot;#&quot;,&quot;nationalteam&quot;:&quot;National team&quot;,&quot;debut&quot;:&quot;Debut&quot;,&quot;matches&quot;:&quot;Matches&quot;,&quot;goals&quot;:&quot;Goals&quot;,&quot;linkTitle&quot;:&quot;Go to national player profile&quot;,&quot;coachAtDebut&quot;:&quot;Coach at debut&quot;,&quot;ageAtDebut&quot;:&quot;Age at debut&quot;}"
+    ></tm-player-national-team-career>
+            <div class="box">
+                <h2 class="content-box-headline">
+                    Stats of Marc Casadó                </h2>
+                <p class="info-content">
+                    This snapshot overview displays all of the international games recorded for a particular player in the TM database. Under "Filter by national team", you can filter by appearances for senior national team(s) and appearances for U-xx teams. This will also cause the corresponding information to be shown under "Detailed stats". By clicking on the "Detailed" tab, you can view further details (e.g. substitutions on and off, penalty goals, etc.) for your selected category.                </p>
+                <div class="content">
+                    <form class="js-form-params2path" action="/marc-casado/nationalmannschaft/spieler/636695/plus/0" method="post">
+                        <div class="row">
+                            <div class="large-12 columns">
+                                <table class="auflistung">
+                                    <tbody>
+                                        <tr>
+                                            <td>Filter by national team:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="verein_id" data-placeholder="Filter by national team" class="chzn-select" tabindex="0">
+                                                                                                                    <option  selected="selected"value="3375">Spain</option>
+                                                                                                                    <option value="9567">Spain U21</option>
+                                                                                                                    <option value="12395">Spain U17</option>
+                                                                                                                    <option value="33775">Spain U16</option>
+                                                                                                            </select>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <input type="submit" class="small button" value="Show">
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        </form>                </div>
+                
+<div class="tm-tabs">
+    <a class="tm-tab tm-tab__active--parent" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375/hauptwettbewerb//wettbewerb_id//start/2024-11-15/ende/2024-11-18/nurEinsatz/0"><div class=" tm-tab__active"><span>Compact</span></div></a><a class="tm-tab" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375/hauptwettbewerb//wettbewerb_id//start/2024-11-15/ende/2024-11-18/nurEinsatz/0/plus/1"><div class=""><span>Detailed</span></div></a></div>
+                <div class="responsive-table">
+                    <div id="yw0" class="grid-view">
+<div class="summary"></div>
+<table class="items">
+<thead>
+<tr>
+<th colspan="2" id="yw0_c0">Competition</th><th class="hide" id="yw0_c1">wettbewerb</th><th class="zentriert" id="yw0_c2"><span class="icons_sprite icon-einsaetze-table-header" title="Appearances">&nbsp;</span></th><th class="zentriert" id="yw0_c3"><span class="icons_sprite icon-tor-table-header" title="Goals">&nbsp;</span></th><th class="zentriert" id="yw0_c4"><span class="icons_sprite icon-vorlage-table-header" title="Assists">&nbsp;</span></th><th class="zentriert" id="yw0_c5"><span class="icons_sprite icon-gelbekarte-table-header" title="Yellow cards">&nbsp;</span></th><th class="zentriert" id="yw0_c6"><span class="icons_sprite icon-gelbrotekarte-table-header" title="Second yellow cards">&nbsp;</span></th><th class="zentriert" id="yw0_c7"><span class="icons_sprite icon-rotekarte-table-header" title="Red cards">&nbsp;</span></th><th class="rechts" id="yw0_c8"><span class="icons_sprite icon-minuten-table-header" title="Minutes played">&nbsp;</span></th></tr>
+</thead>
+<tfoot>
+<tr>
+<td colspan="2" class="rechts">Total : </td><td class="hide">&nbsp;</td><td class="zentriert">2</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="rechts">110'</td></tr>
+</tfoot>
+<tbody>
+<tr class="odd">
+<td class="hauptlink no-border-rechts"><img src="https://tmssl.akamaized.net//images/logo/tiny/unla.png?lm=1512858223" title="UEFA Nations League A" alt="UEFA Nations League A" class="" /></td><td class="hauptlink no-border-links"><a title="UEFA Nations League" href="/uefa-nations-league-a/startseite/pokalwettbewerb/UNLA">UEFA Nations League</a></td><td class="zentriert"><a title="Marc Casadó" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375/hauptwettbewerb/UNL">2</a></td><td class="zentriert"><a title="Marc Casadó" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375/hauptwettbewerb/UNL/nurEinsatz/2">-</a></td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="rechts">110'</td></tr>
+</tbody>
+</table>
+<div class="keys" style="display:none" title="/marc-casado/nationalmannschaft/spieler/636695"><span>UEFA Nations League</span></div>
+</div>                </div>
+            </div>
+                            <div class="box">
+                    <h2 class="content-box-headline">
+                        Detailed stats                    </h2>
+                    <p class="info-content">
+                        This overview shows all of a player's call-ups for the national team selected under "Stats". You can use a filter to limit the selection to major competitions (e.g. world cups), individual competitions (e.g. WC 2014) and to specific time periods. Under "Matches", you can also filter by actual number of matches played or by all matches with goals scored. Under the "Detailed" tab, you can view further details such as the venue and club for which the player was playing at the time of the match.                    </p>
+                    <div class="content">
+                        <form action="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375/plus/0" method="get">                        <div class="row">
+                            <div class="large-12 columns">
+                                <table class="auflistung">
+                                    <tbody>
+                                        <tr>
+                                            <td>Filter by major competition:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="hauptwettbewerb" data-placeholder="Filter by competition" class="chzn-select" tabindex="0">
+                                                        <option value="">All</option>
+                                                                                                                    <option value="UNL">UEFA Nations League</option>
+                                                                                                            </select>
+                                                </div>
+                                            </td>
+                                            <td>
+
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Filter by competition:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="wettbewerb_id" data-placeholder="Filter by competition" class="chzn-select" tabindex="0">
+                                                        <option value="">All</option>
+                                                                                                                    <option value="UNLA">UEFA Nations League A</option>
+                                                                                                            </select>
+                                                </div>
+                                            </td>
+                                            <td>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Filter by coach:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="trainer_id" data-placeholder="Filter by coach" class="chzn-select" tabindex="0">
+                                                        <option value="">All</option>
+                                                                                                                    <option value="20031">Luis de la Fuente</option>
+                                                                                                            </select>
+                                                </div>
+                                            </td>
+                                            <td>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                Period:                                            </td>
+                                            <td>
+                                                <input class="" style="font-weight:normal !important;" id="start" type="text" value="15/11/2024" name="start" />                                            </td>
+                                            <td class="zentriert hauptlink">-</td>
+                                            <td>
+                                                <input class="" id="ende" type="text" value="18/11/2024" name="ende" />                                            </td>
+                                            <td>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Matches:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="nurEinsatz" data-placeholder="Choose matches" class="chzn-select" tabindex="0">
+                                                        <option  selected="selected" value="0">All games</option>
+                                                        <option  value="1">Only games where the player appeared</option>
+                                                        <option  value="2">Only games with goals scored</option>
+                                                    </select>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <input type="submit" class="small button" value="Show">
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        </form>                    </div>
+                    
+<div class="tm-tabs">
+    <a class="tm-tab tm-tab__active--parent" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375/hauptwettbewerb//wettbewerb_id//start/2024-11-15/ende/2024-11-18/nurEinsatz/0"><div class=" tm-tab__active"><span>Compact</span></div></a><a class="tm-tab" href="/marc-casado/nationalmannschaft/spieler/636695/verein_id/3375/hauptwettbewerb//wettbewerb_id//start/2024-11-15/ende/2024-11-18/nurEinsatz/0/plus/1"><div class=""><span>Detailed</span></div></a></div>
+                    <div class="responsive-table">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th class="zentriert">&nbsp;</th>
+                                    <th class="zentriert">Matchday</th>
+                                                                            <th class="zentriert">Date</th>
+
+                                                                                    <th class="zentriert">Venue</th>
+                                            <th class="zentriert" colspan="2">For</th>
+                                            <th colspan="2">Opponent</th>
+                                                                            
+                                                                            <th class="zentriert">Result</th>
+                                    
+                                    <th class="zentriert">Pos.</th>
+                                    <th class="zentriert"><span class="icons_sprite icon-tor-table-header" title="Goals">&nbsp;</span></th>
+                                    <th class="zentriert"><span class="icons_sprite icon-vorlage-table-header" title="Assists">&nbsp;</span></th>
+                                                                                                                <th class="zentriert"><span class="icons_sprite icon-gelbekarte-table-header" title="Yellow cards">&nbsp;</span></th>
+                                        <th class="zentriert"><span class="icons_sprite icon-gelbrotekarte-table-header" title="Second yellow cards">&nbsp;</span></th>
+                                        <th class="zentriert"><span class="icons_sprite icon-rotekarte-table-header" title="Red cards">&nbsp;</span></th>
+                                                                                                            <th class="rechts"><span class="icons_sprite icon-minuten-table-header" title="Minutes played">&nbsp;</span></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                                                                                                            <tr>
+                                                    <td class="zentriert hauptlink no-border-rechts" style="border-top:1px solid #ddd;border-bottom: none !important;background-color: #f2f2f2 !important;">
+                                                        <a name="UNLA" href="/uefa-nations-league-a/startseite/pokalwettbewerb/UNLA/saison_id/2024">
+
+                                                            <img src="https://tmssl.akamaized.net//images/logo/tiny/unla.png?lm=1512858223" title="UEFA Nations League A" alt="UEFA Nations League A" class="" />                                                        </a>
+                                                    </td>
+                                                    <td colspan="20" class=" hauptlink no-border-links" style="border-top:1px solid #ddd;background-color: #f2f2f2 !important;">
+                                                        <a name="UNLA" href="/uefa-nations-league-a/startseite/pokalwettbewerb/UNLA/saison_id/2024">
+                                                            UEFA Nations League A                                                        </a>
+                                                    </td>
+                                                </tr>
+                                                                                        <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group 4</td>
+                                                                                                    <td class="zentriert">15/11/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Denmark" href="/danemark/spielplan/verein/3436/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/39.png?lm=1520611569" title="Denmark" alt="Denmark" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Denmark" href="/danemark/spielplan/verein/3436/saison_id/2024">Denmark</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4284261" href="/spielbericht/index/spielbericht/4284261"><span class="greentext">1:2 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Defensive Midfield">DM</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">20'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group 4</td>
+                                                                                                    <td class="zentriert">18/11/24</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Switzerland" href="/schweiz/spielplan/verein/3384/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/148.png?lm=1520611569" title="Switzerland" alt="Switzerland" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Switzerland" href="/schweiz/spielplan/verein/3384/saison_id/2024">Switzerland</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4284259" href="/spielbericht/index/spielbericht/4284259"><span class="greentext">3:2 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Defensive Midfield">DM</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">90'</td>
+                                                                                            </tr>
+                                                                </tbody>
+                            <foot>
+                                <tr>
+                                    <td colspan="20">Squad: 2, Starting eleven: 1, Substituted in: 1, On the bench: 0, Suspended: 0, Injured: 0, </td>
+                                </tr>
+                            </foot>
+                        </table>
+                    </div>
+                </div>
+
+                </div>
+                    <div class="large-4 columns">
+                <script type="text/javascript">//RWGzztV("rectangle1")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-rectangle1"  data-ad-placement-note="Advertisement">
+  <div id="d_side_1" style="min-width: 336px; min-height: 280px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_side_1");
+        let has_d_side_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_side_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_side_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_side_1]);
+                has_d_side_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_side_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+                                <script type="text/javascript">//RWGzztV("rectangle2")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-rectangle2"  data-ad-placement-note="Advertisement">
+  <div id="d_side_2" style="min-width: 336px; min-height: 280px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_side_2");
+        let has_d_side_2_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_side_2_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_side_2", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_side_2]);
+                has_d_side_2_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_side_2"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+            </div>
+            </div>
+
+<script async src="/js/custom/tm-track-links.min.js" type="module"></script>
+
+<div class="ad-placement-note ad-placement-background werbung werbung-fullsize_contentad"  data-ad-placement-note="Advertisement">
+  <div id="d_bottom_1" style="min-width: 1024px; min-height: 250px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_bottom_1");
+        let has_d_bottom_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_bottom_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_bottom_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_bottom_1]);
+                has_d_bottom_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_bottom_1"));
+      });
+    </script>
+  </div>
+</div>
+
+
+        </main>
+        <footer class="tm-footer">
+               <section class="tm-footer__section-quick-links">
+        <strong class="tm-footer__headline tm-footer__headline--large">
+            Quick Links        </strong>
+        <div class="tm-footer__link-wrapper">
+            <a href="/spieler-statistik/wertvollstespieler/marktwertetop"
+               onclick="tmEvent('footer', 'quick_links', '/spieler-statistik/wertvollstespieler')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Most valuable players in the world            </a>
+            <a href="/statistik/neuestetransfers"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/neuestetransfers')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest transfers            </a>
+            <a href="/geruechte/aktuellegeruechte/statistik"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/aktuellegeruechte')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest rumours            </a>
+            <a href="/spieler-statistik/marktwertaenderungen/marktwertetop"
+                onclick="tmEvent('footer', 'quick_links', '/spieler-statistik/marktwertaenderungen/marktwertetop')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest market value updates            </a>
+            <a href="/statistik/weltrangliste"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/weltrangliste')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                FIFA World ranking            </a>
+                        <a href="/betting/"
+                onclick="tmEvent('footer', 'quick_links', '/betting/')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Betting            </a>
+                    </div>
+    </section>
+                <section class="tm-footer__section-involved">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                Be Involved            </strong>
+            <div class="tm-footer__link-wrapper">
+                <a href="/intern/paten"
+                    onclick="tmEvent('footer', 'be_involved', 'mods_data_scouts')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Mods & Data Scouts                </a>
+                <a href="/profil/bewerbung"
+                    onclick="tmEvent('footer', 'be_involved', 'apply_mod_datascout')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Apply as Mod or Datascout                </a>
+                <a href="/intern/elfGebote"
+                    onclick="tmEvent('footer', 'be_involved', '11_commandments')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    11 commandments                </a>
+                <a href="/intern/fehlermelden"
+                    onclick="tmEvent('footer', 'be_involved', 'found_mistake')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Found a mistake?                </a>
+            </div>
+        </section>
+        <section class="tm-footer__section-career">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                Career            </strong>
+            <div class="tm-footer__link-wrapper">
+                                <a href="/intern/tmteam"
+                   class="tm-footer__link tm-footer__link--arrow"
+                   onclick="tmEvent('footer', 'career', 'contact')"
+                >
+                    Contact                </a>
+            </div>
+        </section>
+        <section class="tm-footer__section-about">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                About Us            </strong>
+            <div class="tm-footer__link-wrapper">
+                <a href="/intern/tmteam"
+                   onclick="tmEvent('footer', 'about_us', 'tm_team')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    TM-Team                </a>
+                <a href="/intern/faq"
+                   onclick="tmEvent('footer', 'about_us', 'faq')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    FAQ                </a>
+            </div>
+        </section>
+            <section class="tm-footer__section-social">
+        <strong class="tm-footer__headline
+            ">
+            Social media        </strong>
+        <div class="tm-footer__social-wrapper">
+                        <a href="https://www.instagram.com/transfermarkt_official/"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'instagram')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/instaRebrush.svg"
+                         alt="instagram"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.facebook.com/transfermarkt.global"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'facebook')">
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/fbRebrush.svg"
+                         alt="facebook"
+                         width="25"
+                         height="25"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.whatsapp.com/channel/0029Va6Kevx47XeF0gE99J35"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'whatsapp')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/whatsappRebrush.svg"
+                         alt="whatsapp"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://twitter.com/TMuk_news"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'x')">
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/twitter_rebrush.svg"
+                         alt="x"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.threads.net/@transfermarkt_official"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'threads')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/threadsRebrush.svg"
+                         alt="threads"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.tiktok.com/@transfermarkt"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'tiktok')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/tiktokRebrush.svg"
+                         alt="tiktok"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.youtube.com/@TransfermarktEnglish"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'youtube')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/RebrushYoutube.svg"
+                         alt="youtube"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://t.me/transfermarkt_off"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'telegram')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/telegramRebrush.svg"
+                         alt="telegram"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                        </div>
+    </section>
+                </footer>
+                <div id="menue_overlay"></div>
+    </div>
+    <section class="tm-footer__mobile tm-footer__transfermarkt-info">
+        <section class="tm-footer__section-desktop-width">
+                            <section class="tm-footer__section-company-links">
+                    <span class="tm-footer__headline tm-footer__headline--medium">
+                        Transfermarkt Company Projects                    </span>
+                    <div class="tm-footer__project-wrapper">
+                        <a href="/wahretabelle"
+                           onclick="tmEvent('footer', 'projects', 'wahretabelle')"
+                           class="tm-footer__link"
+                        >
+                            Wahretabelle                        </a>
+                        <a href="https://www.soccerdonna.de/"
+                           onclick="tmEvent('footer', 'projects', 'soccerdonna')"
+                           class="tm-footer__link"
+                        >
+                            Soccerdonna.de                        </a>
+                        <a href="https://scoutastic.com/de/"
+                           onclick="tmEvent('footer', 'projects', 'scoutastic')"
+                           class="tm-footer__link"
+                        >
+                            Scoutastic.com                        </a>
+                    </div>
+                </section>
+                        <section class="tm-footer__section-company-infos">
+                <span class="tm-footer__headline tm-footer__headline--medium">&copy; Transfermarkt <span id="currentYear">2026</span></span>
+                <div class="tm-footer__company-wrapper">
+                    <a
+                    href="/intern/impressum"
+                    class="tm-footer__link tm-footer__link--blue"
+                    onclick="tmEvent('footer', 'officials', 'impressum')"
+                    >
+                        Legal notice                    </a>
+                    <a
+                        href="/intern/web/datenschutz"
+                        class="tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'data_protection')"
+                        >
+                        Data protection                    </a>
+                    <a
+                        href="javascript:void(0)"
+                        class="cmp-link tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'privacy')"
+                    >
+                        Privacy                    </a>
+                    <a
+                        href="javascript:void(0)"
+                        class="revoke-tracking tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'tracking_revocation')"
+                    >
+                        Revoke Tracking                    </a>
+                    <a
+                        href="/intern/anb"
+                        class="tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'general_conduct_of_use')"
+                        >
+                        Site policy                    </a>
+                                    </div>
+            </section>
+        </section>
+    </section>
+    <script type="text/javascript">
+	if(typeof(adet) == "boolean" && adet == false){
+		img_src="/static/singlepictures/jk99hhfsdh209nbnkjldgh90sghfsdlk";
+	} else {
+		img_src="/static/singlepictures/jku90whjlkjbwbta1g4b8h89fh8sgh8d";
+	}
+	var elem = document.createElement("img");
+	document.body.appendChild(elem);
+	elem.src = img_src;
+</script>
+
+            <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                var cnt = document.querySelectorAll('div.large-4.columns').length;
+                if (cnt == 1) {
+                    var sidebarDiv = document.querySelector('div.large-4.columns');
+                    if (sidebarDiv !== null) {
+                        var sidebar = document.getElementById('werbung_recommender_sidebar_wrapper');
+                        sidebarDiv.appendChild(sidebar);
+                        sidebar.style.display = 'block';
+                    }
+                }
+            });
+        </script>
+        <div id="werbung_recommender_sidebar_wrapper" style="display: none;">
+                    </div>
+    <tm-consent type="adition" no-checkbox embed="PHNjcmlwdCBzcmM9Imh0dHBzOi8vY3JlYXRpdmUtY2RuLm9kZHNzZXJ2ZS5jb20vbG9hZGVyLmpzP3B1Ymxpc2hlcj10bSIgYXN5bmM9ImFzeW5jIj48L3NjcmlwdD4="></tm-consent><tm-consent type='adrenalead' no-checkbox embed='PHNjcmlwdCB0eXBlPSd0ZXh0L2phdmFzY3JpcHQnPgogICAgICAgICAgICB3aW5kb3cuX25BZHpxPXdpbmRvdy5fbkFkenF8fFtdOyhmdW5jdGlvbigpewogICAgICAgICAgICB3aW5kb3cuX25BZHpxLnB1c2goWydzZXRJZHMnLCdkNWE0YzFhNzU4Njc4YTUxJ10pOwogICAgICAgICAgICB2YXIgZT0naHR0cHM6Ly9ub3RpZnB1c2guY29tL3NjcmlwdHMvJzsKICAgICAgICAgICAgdmFyIHQ9ZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7CiAgICAgICAgICAgIHQudHlwZT0ndGV4dC9qYXZhc2NyaXB0JzsKICAgICAgICAgICAgdC5kZWZlcj10cnVlOwogICAgICAgICAgICB0LmFzeW5jPXRydWU7CiAgICAgICAgICAgIHQuc3JjPWUrJ25hZHotc2RrLmpzJzsKICAgICAgICAgICAgdmFyIHM9ZG9jdW1lbnQuZ2V0RWxlbWVudHNCeVRhZ05hbWUoJ3NjcmlwdCcpWzBdOwogICAgICAgICAgICBzLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKHQscyl9KSgpOwogICAgICAgIDwvc2NyaXB0Pg=='></tm-consent>    
+        <tm-modal id="tm-modal-revoke-tracking" additionalClose="Close">
+        <div class="tm-modal__headline">Revoke Tracking</div>
+        <p class="tm-modal__text">Sie haben erfolgreich Ihre Einwilligung in die Nutzung von Transfermarkt mit Tracking und Cookies widerrufen. Sie können sich jetzt zwischen dem Contentpass-Abo und der Nutzung mit personalisierter Werbung, Cookies und Tracking entscheiden.</p>
+    </tm-modal>
+
+<tm-consent type="pubmatic" no-checkbox embed="PHNjcmlwdCB0eXBlPSd0ZXh0L2phdmFzY3JpcHQnPgogICAgICAgICAgICAgICAgICAgICAgICB2YXIgUFdUPXt9OwogICAgICAgICAgICAgICAgICAgICAgICB2YXIgZ29vZ2xldGFnID0gZ29vZ2xldGFnIHx8IHt9OwogICAgICAgICAgICAgICAgICAgICAgICBnb29nbGV0YWcuY21kID0gZ29vZ2xldGFnLmNtZCB8fCBbXTsKICAgICAgICAgICAgICAgICAgICAgICAgdmFyIGdwdFJhbiA9IGZhbHNlOwogICAgICAgICAgICAgICAgICAgICAgICBQV1QuanNMb2FkZWQgPSAoKSA9PiB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBsb2FkR1BUKCk7CiAgICAgICAgICAgICAgICAgICAgICAgIH07CiAgICAgICAgICAgICAgICAgICAgICAgIHZhciBsb2FkR1BUID0gZnVuY3Rpb24oKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBpZiAoIWdwdFJhbikgewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdwdFJhbiA9IHRydWU7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIGdhZHMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdzY3JpcHQnKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgdXNlU1NMID0gJ2h0dHBzOicgPT0gZG9jdW1lbnQubG9jYXRpb24ucHJvdG9jb2w7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ2Fkcy5zcmMgPSAodXNlU1NMID8gJ2h0dHBzOicgOiAnaHR0cDonKSArICcvL3NlY3VyZXB1YmFkcy5nLmRvdWJsZWNsaWNrLm5ldC90YWcvanMvZ3B0LmpzJzsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbm9kZSA9IGRvY3VtZW50LmdldEVsZW1lbnRzQnlUYWdOYW1lKCdzY3JpcHQnKVswXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBub2RlLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKGdhZHMsIG5vZGUpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgICAgICB9OwogICAgICAgICAgICAgICAgICAgICAgICAvLyBGYWlsc2FmZSB0byBjYWxsIGdwdAogICAgICAgICAgICAgICAgICAgICAgICBzZXRUaW1lb3V0KGxvYWRHUFQsIDUwMCk7CgogICAgICAgICAgICAgICAgICAgICAgICAoZnVuY3Rpb24oKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgcHVybCA9IHdpbmRvdy5sb2NhdGlvbi5ocmVmOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIHVybCA9ICcvL2Fkcy5wdWJtYXRpYy5jb20vQWRTZXJ2ZXIvanMvcHd0LzE2MzIyOS8xMDEwMyc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgcHJvZmlsZVZlcnNpb25JZCA9ICcnOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgaWYocHVybC5pbmRleE9mKCdwd3R2PScpPjApewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhciByZWdleHAgPSAvcHd0dj0oLio/KSgmfCQpL2c7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbWF0Y2hlcyA9IHJlZ2V4cC5leGVjKHB1cmwpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgaWYobWF0Y2hlcy5sZW5ndGggPj0gMiAmJiBtYXRjaGVzWzFdLmxlbmd0aCA+IDApewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb2ZpbGVWZXJzaW9uSWQgPSAnLycrbWF0Y2hlc1sxXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIHd0YWRzID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy5hc3luYyA9IHRydWU7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy50eXBlID0gJ3RleHQvamF2YXNjcmlwdCc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy5zcmMgPSB1cmwrcHJvZmlsZVZlcnNpb25JZCsnL3B3dC5qcyc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbm9kZSA9IGRvY3VtZW50LmdldEVsZW1lbnRzQnlUYWdOYW1lKCdzY3JpcHQnKVswXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG5vZGUucGFyZW50Tm9kZS5pbnNlcnRCZWZvcmUod3RhZHMsIG5vZGUpOwogICAgICAgICAgICAgICAgICAgICAgICB9KSgpOwogICAgICAgICAgICAgICAgICAgIDwvc2NyaXB0PgogICAgICAgICAgICAgICAgICAgIA=="></tm-consent><tm-consent type="googleadvertising" no-checkbox embed="PHNjcmlwdCAgc3JjPSJodHRwczovL3NlY3VyZXB1YmFkcy5nLmRvdWJsZWNsaWNrLm5ldC90YWcvanMvZ3B0LmpzIiBhc3luYz0iYXN5bmMiPjwvc2NyaXB0Pg=="></tm-consent>
+<tm-consent type="googleadvertising" no-checkbox embed="PHNjcmlwdCAgc3JjPSJodHRwczovL2MuYW1hem9uLWFkc3lzdGVtLmNvbS9hYXgyL2Fwc3RhZy5qcyIgYXN5bmM9ImFzeW5jIj48L3NjcmlwdD4="></tm-consent>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/watchlist/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/subnavigation/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-national-team-career/bundle.js"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/assets/aa69c6e9c51f1e811847082c63633956/gridview/jquery.yiigridview.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/assets/b7c5571cf8957553f95f6d9069eaed67/jui/js/jquery-ui.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/custom/vendors.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/domain-switcher/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/quick-select-bar/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/userbox/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/live-match-count/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/domain-note/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/consent/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/modal/bundle.js"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/custom/tm-skyscraper.min.js?lm=1767953048"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+	var loginUrl='/profil/login';
+	var onlyDE = '';
+	var onlyMobile = '';
+	var onlyTablet = '';
+	var getUserID = '';
+
+jQuery(function($) {
+jQuery('#yw0').yiiGridView({'ajaxUpdate':['yw0'],'ajaxVar':'ajax','pagerClass':'pager','loadingClass':'grid\x2Dview\x2Dloading','filterClass':'filters','tableClass':'items','selectableRows':1,'enableHistory':false,'updateSelector':'\x7Bpage\x7D,\x20\x7Bsort\x7D','filterSelector':'\x7Bfilter\x7D','afterAjaxUpdate':function() {window.LazyLoadInstance.update(); tmTrackingAndAds(); trackLinks(); document.dispatchEvent(new CustomEvent("tmInitTooltip"));}});
+jQuery('#start').datepicker({'dateFormat':'dd.mm.yy','yearRange':'\x2D200\x3A\x2B1','changeYear':'true','changeMonth':'true'});
+jQuery('#ende').datepicker({'dateFormat':'dd.mm.yy','yearRange':'\x2D200\x3A\x2B1','changeYear':'true','changeMonth':'true'});
+});
+/*]]>*/
+</script>
+</body>
+
+</html>

--- a/samples/html/yamal.html
+++ b/samples/html/yamal.html
@@ -1,0 +1,1892 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    
+<script type="text/javascript" data-description="sourcepoint stub code">
+    !function () { var e = function () { var e, t = "__tcfapiLocator", a = [], n = window; for (; n;) { try { if (n.frames[t]) { e = n; break } } catch (e) { } if (n === window.top) break; n = n.parent } e || (!function e() { var a = n.document, r = !!n.frames[t]; if (!r) if (a.body) { var i = a.createElement("iframe"); i.style.cssText = "display:none", i.name = t, a.body.appendChild(i) } else setTimeout(e, 5); return !r }(), n.__tcfapi = function () { for (var e, t = arguments.length, n = new Array(t), r = 0; r < t; r++)n[r] = arguments[r]; if (!n.length) return a; if ("setGdprApplies" === n[0]) n.length > 3 && 2 === parseInt(n[1], 10) && "boolean" == typeof n[3] && (e = n[3], "function" == typeof n[2] && n[2]("set", !0)); else if ("ping" === n[0]) { var i = { gdprApplies: e, cmpLoaded: !1, cmpStatus: "stub" }; "function" == typeof n[2] && n[2](i) } else a.push(n) }, n.addEventListener("message", (function (e) { var t = "string" == typeof e.data, a = {}; try { a = t ? JSON.parse(e.data) : e.data } catch (e) { } var n = a.__tcfapiCall; n && window.__tcfapi(n.command, n.version, (function (a, r) { var i = { __tcfapiReturn: { returnValue: a, success: r, callId: n.callId } }; t && (i = JSON.stringify(i)), e.source.postMessage(i, "*") }), n.parameter) }), !1)) }; "undefined" != typeof module ? module.exports = e : e() }();
+</script>
+<script data-description="sourcepoint configuration">
+window._sp_ = {
+    config: {"accountId":1254,"propertyId":7427,"gdpr":{"consentLanguage":"en","targetingParams":{"acps":"false"}},"baseEndpoint":"https://cdn.privacy-mgmt.com","isSPA":true,"cpPropertyId":"7a84b340"}}
+</script>
+<script src="https://cdn.privacy-mgmt.com/wrapperMessagingWithoutDetection.js" async></script>
+<script type="text/javascript" data-description="contentpass integration">
+    (function() {
+        var cpBaseUrl = 'https://cp.transfermarkt.com';
+        var cpController = cpBaseUrl + '/now.js';
+        var cpPropertyId = '7a84b340';
+
+        !function(C,o,n,t,P,a,s){C['CPObject']=n;C[n]||(C[n]=function(){
+        (C[n].q=C[n].q||[]).push(arguments)});C[n].l=+new Date;a=o.createElement(t);
+        s=o.getElementsByTagName(t)[0];a.src=P;s.parentNode.insertBefore(a,s)}
+        (window,document,'cp','script',cpController);
+
+        !function(C,o,n,t,P){if(!C[n].patched){cp('extension','authenticate');P=C[n].q.push;
+        C[n].q.push=function(a){if(a[0]==='authenticate'){if((o['cookie']||'').indexOf('_cpauthhint=')===-1&&
+        !(C['localStorage']||{})['_cpuser']&&C.location.href.toLowerCase().indexOf('cpauthenticated')===-1){
+        t={isLoggedIn:function(){return false;},hasValidSubscription:function(){return false;}};
+        (typeof a[1]==='function'&&a[1](null,t));C[n].afp=true;P.apply(C[n].q,[['authenticate',null]]);
+        return t;}}P.apply(C[n].q,[a]);}}}
+        (window,document,'cp',false);
+
+        cp('create', cpPropertyId, {
+        baseUrl: cpBaseUrl
+        });
+
+        cp('render', {
+        onFullConsent: function() {
+            console.log('[DEMO] onFullConsent');
+        }
+        })
+    })()
+</script>
+
+<script type="text/javascript" data-description="contentpass sourcepoint fast path">
+(function () {
+    cp('authenticate', function(err, user) {
+        if (err || (!user.isLoggedIn() && !user.hasValidSubscription())) {
+        // console.log('[SPCP] Taking fast path');
+        (function spExecMsg() {
+            if (window._sp_ && window._sp_.executeMessaging) {
+            if (!window._sp_.config.isSPA) {
+                // console.warn('[SPCP] Sourcepoint not in SPA mode!');
+            } else if (window._sp_.version) {
+                // console.log('[SPCP] Sourcepoint already running');
+            } else {
+                // console.log('[SPCP] Starting Sourcepoint');
+                window._sp_.executeMessaging();
+            }
+            } else {
+            // console.log('[SPCP] Sourcepoint not loaded yet. Retrying.');
+            setTimeout(spExecMsg, 10);
+            }
+        })();
+        }
+    });
+    })();
+</script>
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="shortcut icon" sizes="192x192" href="/android-chrome-192x192.png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=no" />
+<meta name="keywords" content="Lamine Yamal,FC Barcelona,LaLiga,Spain" />
+<meta name="description" content="Lamine Yamal, 18, from Spain ➤ FC Barcelona, since 2023 ➤ Right Winger ➤ Market value: €200.00m ➤ * 13/07/2007 in Esplugues de Llobregat, Spain " />
+<meta property="og:type" content="article" />
+<meta property="og:image" content="https://img.a.transfermarkt.technology/portrait/big/937958-1746563945.jpg?lm=1" />
+<meta property="og:description" content="" />
+<meta property="twitter:image" content="https://img.a.transfermarkt.technology/portrait/big/937958-1746563945.jpg?lm=1" />
+<meta property="og:title" content="Lamine Yamal - Player profile 25/26" />
+<meta property="twitter:title" content="Lamine Yamal - Player profile 25/26" />
+<meta property="og:url" content="https://www.transfermarkt.com/lamine-yamal/profil/spieler/937958" />
+<link hreflang="de" rel="alternate" href="https://www.transfermarkt.de/lamine-yamal/profil/spieler/937958" />
+<link hreflang="de-LU" rel="alternate" href="https://www.transfermarkt.de/lamine-yamal/profil/spieler/937958" />
+<link hreflang="de-AT" rel="alternate" href="https://www.transfermarkt.at/lamine-yamal/profil/spieler/937958" />
+<link hreflang="de-CH" rel="alternate" href="https://www.transfermarkt.ch/lamine-yamal/profil/spieler/937958" />
+<link hreflang="tr" rel="alternate" href="https://www.transfermarkt.com.tr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="it-CH" rel="alternate" href="https://www.transfermarkt.it/lamine-yamal/profil/spieler/937958" />
+<link hreflang="it" rel="alternate" href="https://www.transfermarkt.it/lamine-yamal/profil/spieler/937958" />
+<link hreflang="pl" rel="alternate" href="https://www.transfermarkt.pl/lamine-yamal/profil/spieler/937958" />
+<link hreflang="en-GB" rel="alternate" href="https://www.transfermarkt.co.uk/lamine-yamal/profil/spieler/937958" />
+<link hreflang="en-IE" rel="alternate" href="https://www.transfermarkt.co.uk/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-ES" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-CL" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-VE" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-EC" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-CU" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/profil/spieler/937958" />
+<link hreflang="nl" rel="alternate" href="https://www.transfermarkt.nl/lamine-yamal/profil/spieler/937958" />
+<link hreflang="pt" rel="alternate" href="https://www.transfermarkt.pt/lamine-yamal/profil/spieler/937958" />
+<link hreflang="ru" rel="alternate" href="https://www.transfermarkt.world/lamine-yamal/profil/spieler/937958" />
+<link hreflang="fr-CH" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="fr" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="fr-CA" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="fr-CI" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="fr-LU" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="fr-BE" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="pt-BR" rel="alternate" href="https://www.transfermarkt.com.br/lamine-yamal/profil/spieler/937958" />
+<link hreflang="en-US" rel="alternate" href="https://www.transfermarkt.us/lamine-yamal/profil/spieler/937958" />
+<link hreflang="en-CA" rel="alternate" href="https://www.transfermarkt.us/lamine-yamal/profil/spieler/937958" />
+<link hreflang="en-IN" rel="alternate" href="https://www.transfermarkt.co.in/lamine-yamal/profil/spieler/937958" />
+<link hreflang="en-ZA" rel="alternate" href="https://www.transfermarkt.co.za/lamine-yamal/profil/spieler/937958" />
+<link hreflang="x-default" rel="alternate" href="https://www.transfermarkt.com/lamine-yamal/profil/spieler/937958" />
+<link hreflang="en" rel="alternate" href="https://www.transfermarkt.com/lamine-yamal/profil/spieler/937958" />
+<link hreflang="nl-BE" rel="alternate" href="https://www.transfermarkt.be/lamine-yamal/profil/spieler/937958" />
+<link hreflang="ro" rel="alternate" href="https://www.transfermarkt.ro/lamine-yamal/profil/spieler/937958" />
+<link hreflang="el-GR" rel="alternate" href="https://www.transfermarkt.gr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="ko-KR" rel="alternate" href="https://www.transfermarkt.co.kr/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-AR" rel="alternate" href="https://www.transfermarkt.com.ar/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-MX" rel="alternate" href="https://www.transfermarkt.mx/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-CO" rel="alternate" href="https://www.transfermarkt.co/lamine-yamal/profil/spieler/937958" />
+<link hreflang="es-PE" rel="alternate" href="https://www.transfermarkt.pe/lamine-yamal/profil/spieler/937958" />
+<link hreflang="ms" rel="alternate" href="https://www.transfermarkt.my/lamine-yamal/profil/spieler/937958" />
+<link hreflang="ja" rel="alternate" href="https://www.transfermarkt.jp/lamine-yamal/profil/spieler/937958" />
+<link hreflang="id" rel="alternate" href="https://www.transfermarkt.co.id/lamine-yamal/profil/spieler/937958" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-main.min.css?lm=1767953972" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/stylesheets/main_desktop.css?lm=1767953048" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-discover.min.css?lm=1767953972" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-button-list.min.css?lm=1767953972" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-link-list.min.css?lm=1767953972" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-print.min.css?lm=1767953972" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/stylesheets/main.css?lm=1767953048" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-player-profile.min.css?lm=1767953972" />
+<style type="text/css">
+/*<![CDATA[*/
+@keyframes heim {
+    0%   {width: 0%;}
+    100% {width: 0%}
+}
+@keyframes gast {
+    0%   {width: 0%;}
+    100% {width: 0%}
+}
+.fav-voting__home {
+    animation-name: heim;
+    animation-duration: 4s;
+}
+.fav-voting__visitor {
+    animation-name: gast;
+    animation-duration: 4s;
+}
+/*]]>*/
+</style>
+<style type="text/css">
+/*<![CDATA[*/
+
+                .ad-placement-background {
+                    background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxODk2IDgwNyI+CiAgPHBhdGggZD0iTTEwNTYuMyA1MzIuNGMwLTE3LjEtMTUuMy0yOS4yLTMyLTMzLjktMTEuNS0zLjItNjUuNi0xMC42LTExNi45IDAtMTQuNiAzLTYxLjUgMTkuNy02MC43IDM4LjQuNSAxMC42IDE4LjQgMTEuOSAyNS43IDExLjkgMzguNyAwIDQ5LjEtMjIuNyA4Mi42LTIyLjdzMjcuMi0xLjQgMjcuMiAxNC44LTMzLjMgMjEuNS0zNy4yIDIyYy0xNy40IDIuNC04NC42IDEyLjQtMTA4LjYgMjUuMy0zNi40IDE5LjUtNDcgNDAuNi00NyA1Mi42IDAgMzcuNyA1MC43IDQwLjYgNzEuNyA0MC42IDMxLjQgMCA0NS42LTEwLjkgNzEuNy0xMC45czMyLjYgNi41IDQyIDYuOWM3LjMuMyAxMy45LTEuNCAxOS45LTMuMyAxNy4yLTUuNSAxOC4yLTIzLjEgMjMuMy0zNC42IDExLjEtMjUuNSAyMS42LTUxLjMgMzEuMS03Ny4yIDMuNC05LjkgNy4zLTE5LjggNy4zLTI5LjlabS0xNDQuOCAxMDljLTYuNyAxLjUtOS44IDIuMS0xNy40IDIuNC04LjUuMy0yNi43LTMuNS0yNi43LTE1LjMgMC0yNC40IDYzLjUtMzMuMiA3Mi43LTMzLjIgMTEuMi0uNCAxOC4zIDIuNyAxOC4zIDkuOSAwIDIwLjgtNDQuNiAzNS43LTQ2LjkgMzYuMlpNNzkzLjkgNTA3LjVjLTQ0LjctMjcuOS0xMDcuMiA1LTEzMC41IDUtMzEuOCAwLTMwLjctMTIuOC02NC44LTE1LTY5LTQuMS05MCAxMi4yLTEwNS4yIDEyLjJzLTkuMy04LjMtMjEuNS02LjdjLTEzLjMgMi4yLTE1LjUgNS0xOS4xIDEwLTQuNSA2LjMtNTMuNSAxMzguOC01Ni41IDE0Ni4xLTExLjEgMjYuMyA1NS43IDI5LjUgNzAuOCA4LjcgMzkuNy01NC45IDMwLjktMTE0LjIgODAuOS0xMjMuOSAxMS44LTIuMyAyMi4zLTIuNiAzMC40IDkuMWwuNC44YzcuMiAxMy4zLTUuNCAzOS44LTEzLjggNjAuNS00LjEgMTAtMTYuNiA0Mi43LTE1LjUgNTQgMS45IDIxLjEgNjYuOCAxNC4xIDc1LjYtMi4xIDE5LjMtMzUuNiAyMy4xLTk2LjkgNDQuMS0xMTMuNCAyNS42LTIwIDQ5LjItNC43IDUxLjMgNC41IDQuMiAxOC4yLTEzLjUgNTIuNy0yMyA3Mi44LTEzLjQgMjguNS03LjMgNTEuMSAyNyA1MS4yIDExLjQgMCAyNy00LjQgMzMuNy0xNC4xIDUuNy04LjMgMTQuNS0zMS42IDI3LjQtNjYuNSAxNC4xLTM4LjEgMjkuMi04MCA4LjMtOTMuMVpNMTIzNSA1MTQuMmMtMS40LTExLTEyLTE1LjYtMjEuMS0xNS4yLTYuNC4yLTE4LjggNS4yLTI4LjYgNS4yLTEwLjcgMC0xNS4yLTIuMS0yOS43LTQuNy0xNy41LTMuMi0zMy4yLTIuNi00My43IDAtMTYuMiA0LTI4LjcgMjAtMzIuMSAzMi44LTUuOCAyMS0xNi42IDQyLjQtMjQuNyA2My4zLTguNyAyMi41LTIzLjcgNjIuMi0yNC40IDcwLjEtLjYgNi45IDcuMiAxNS43IDE1LjIgMTUuNyAwIDAgMzEgLjMgMzcuMS0uMiAyNS0yLjIgMzQuNi0zNi4yIDQwLjMtNTAuNiA0LjctMTEuNyA5LjUtMjQgMTQuMi0zNS42IDMuMS03LjcgNy4zLTE5LjEgMTYuMS0yNy4zIDE3LjItMTYgMzcuNi0xNiA1Ni4zLTIwLjggMTYuOS00LjQgMjYuOC0xOSAyNS4yLTMyLjZaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTM3LjcgNDEuOXY3MjEuN2gxODA5LjhWNDEuOUgzNy43Wm0xNzg5LjEgNzAxSDU4LjNWNjIuNWgxNzY4LjV2NjgwLjRaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTE2MzIuNCA0OTUuOGMtNy44LTMuMS0xNS4yLTYuMi0xMy42LTE0LjIgMy0xNC41IDQuMy0yNC4zLjctMzAuNC0zLjYtNi0xMi4yLTguMy0yOC45LTcuOC0yNi43LjgtMzYuMiA3LjktNDIgMTcuMS01LjkgOS4xLTguMiAyMC4zLTIwLjQgMjkuMi03LjUgNS40LTE1LjkgNy45LTIzIDExLjItNy4xIDMuMy0xNC44IDguOC0xNC44IDE2LjMuMSA4LjQgNSAxMC45IDEwLjEgMTMuOCA1IDIuOSAxMC4yIDUuMyAxMC43IDEwLjguMyAxNi42LTcuOCAzNS43LTE2IDU0LjYtOC4zIDE4LjgtMTYuNyAzNy4zLTE2LjkgNTIuOC0xLjYgMzYuOSA0Ni43IDMxLjkgNTguMSAzMiAxNi4yLS4yIDU3LjkgMi40IDU4LjYtMjkuOCAwLTktNy43LTEyLTE1LjItMTUuMi03LjUtMy4zLTE0LjgtNi44LTE0LjEtMTYuOS4zLTMuNCA1LjQtMTguNSAxMS0zMy44IDUuNi0xNS4zIDExLjctMzAuNiAxMy45LTM0LjMgNi4yLTEwLjQgMjAuOC0xNS40IDMzLjgtMjAuNCAxMy01IDI0LjQtMTAgMjQuNC0yMC40cy04LjMtMTEuMy0xNi4xLTE0LjVaTTE0MDcuOSA1MDkuNmMtMTMuOCA1LTc3LjUgNDktODguMiAzNC41LTguMy0xNC4xIDMxLjctNzguMyAyNS44LTkwLjgtNy45LTE2LjYtNDQuMi05LTUyLjUtNS0xNS4xIDcuMy0yMC4xIDI0LjgtMjUuNyAzOC44LTEwLjcgMjYuOC02NS42IDE2Ny44LTY4LjkgMTc4LjMtNS42IDE3LjkgNTQuNyAzMCA3NC44LTE2LjcgNi4zLTE0LjUgMjQuNi0zMi4zIDQwLjktMzIuMyAzMS45IDAgMjYuNyA2My43IDcwLjQgNjQuNyA0LjggMCAyMy41LjUgMzYuNy01LjcgMjMuNC0xMS4xLTI4LTc2LjUtMjgtOTYuNnM4Ni44LTU3LjEgNzkuNi02Ny43Yy05LjItMTMuNS00Ny45LTcuNy02NS0xLjVaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTMzMC41IDQxMS43WiIgZmlsbD0iI2I0MTAxZiIvPgogIDxwYXRoIGQ9Ik0xNDI0LjQgMjUyLjZoNDAuM2M0LjIgMCAzMiAwIDMxLjMtMTYuOC0uNi0xMy41LTE4LjctMTcuNS0zMy44LTE3LjYtMTIuOS0uMi01NC4yIDYuNS01NC4yIDIzLjZzNS42IDkuOSAxNi41IDEwLjlaTTU3My40IDI4Mi44Yy05LjIgMC03Mi43IDguOC03Mi43IDMzLjJzMTguMiAxNS43IDI2LjcgMTUuM2M3LjYtLjMgMTAuNy0uOSAxNy40LTIuMyAyLjMtLjUgNDYuOS0xNS40IDQ2LjktMzYuMnMtNy4xLTEwLjMtMTguMy05LjlaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZmlsbD0iI2FmMjAwOSIgZD0iTTM0MC40IDc1NC4xeiIvPgogIDxwYXRoIGQ9Ik0zNzcuMiA3MDYuOGMtNi0yMS42LTI1LjktMzYuMS00OC4zLTM1LjItMy44LjEtNy41LjctMTEuMSAxLjctMjUuNiA3LjItNDAuNiAzMy45LTMzLjQgNTkuNSA2LjEgMjEuNiAyNS45IDM2LjEgNDguMyAzNS4yIDMuOC0uMiA3LjUtLjcgMTEuMS0xLjggMTIuNC0zLjUgMjIuNy0xMS42IDI5LTIyLjggNi4zLTExLjIgNy45LTI0LjIgNC40LTM2LjdabS0xNS40IDMwLjVjLTQuNyA4LjMtMTIuMyAxNC4zLTIxLjQgMTYuOC0yLjcuOC01LjUgMS4yLTguMiAxLjNoLTEuNGMtMTYgMC0yOS45LTEwLjUtMzQuMy0yNi0uOS0zLjItMS4zLTYuNC0xLjMtOS42IDAtMTUuNiAxMC4zLTI5LjkgMjYtMzQuMyAyLjctLjcgNS41LTEuMiA4LjItMS4zaDEuNGMxNS45IDAgMjkuOSAxMC41IDM0LjIgMjYgLjkgMy4yIDEuMyA2LjQgMS4zIDkuNiAwIDYtMS42IDEyLTQuNiAxNy40WiIgZmlsbD0iI2Q3ZDdkNyIvPgogIDxwYXRoIGZpbGw9IiNhZjIwMDkiIGQ9Ik0zMjEuMiA2ODUuNXpNMzMwLjQgMzA4LjV6TTMyMy4yIDMwOS43eiIvPgogIDxwYXRoIGQ9Ik0xODA2LjggODEuOEg3OC4zVjQwNmgxNjZjLTM3LjkgMTYuNS03OC4yIDM0LjEtOTEuOCA0MC0xNC40IDYuMS0yMi4xIDIyLjEtMTcuOSAzNy4yIDMuOCAxMy40IDE2LjEgMjIuOCAzMCAyMi44aDEuMmMyLjQgMCA0LjgtLjUgNy4yLTEuMSAxLS4zIDIuMi0uNiAzLjUtMS4xaC4zYzAtLjEgNjgtMzAuOCA2OC0zMC44bC05LjIgMjIuOEwxOTMuOSA1OThsLS4yLjVjLTIuMiA2LjItMi41IDEyLjgtLjcgMTkgMy44IDEzLjYgMTUuOCAyMi44IDI5LjkgMjIuOGgxLjJjLjcgMCAxLjUgMCAyLjEtLjJsLTM0LjQgODQuN3MtMTMuNyAyOC45IDE0LjUgNDEuMWMzMy4xIDE0LjMgNDMuNi0xOC40IDQzLjYtMTguNGw4MC44LTE5OC44IDQxLjItMTAxLjUgMTQuNCA1LjgtMTQuMiAzNC45LTEgMi43LS4yLjljLTEuMiA1LjEtMS4xIDEwLjUuMyAxNS42IDMuOCAxMy40IDE2LjEgMjIuOCAzMCAyMi44aDEuMWMyIDAgNS0uMyA4LjEtMS40IDEwLjctMy43IDE2LjMtOS4yIDIwLjYtMjAuNWwyNS4zLTYyLjJjMi4yLTUuNCA0LTExLjUgMS43LTE5LjQtMi40LTguNy03LjctMTUuMS0xNS0xOC4xbC0uNC0uMmMtLjUtLjItMS4yLS41LTItLjhsLTMuMi0xLjNoMTM2OS40VjgxLjhaTTM0Mi4zIDE4Ni45YzEwLjUtMi42IDI2LjItMy4yIDQzLjcgMCAxNC41IDIuNiAxOSA0LjcgMjkuNyA0LjcgOS44IDAgMjUuNS00LjggMzEuOS00LjkgOC42LS4xIDIxLjUgMi42IDIxLjUgMTQuM3MtMTUuMSAzMC40LTI5IDMzLjdjLTE4LjggNC42LTM5IDQuMy01Ni4xIDIwLjMtOC44IDguMi0xMyAxOS42LTE2LjEgMjcuMy0zIDcuNS02LjEgMTUuMy05LjIgMjMtNS42LTQuNC0xMi4zLTcuNS0xOS42LTguNy0uNSAwLTEuMS0uMi0xLjctLjNoLS4yYy0uNSAwLTEtLjEtMS41LS4ySDMzMGMtMi42IDAtNS4yLjQtNy43IDEtLjguMi0xLjcuNC0yLjUuNi0xLjQuNC0yLjguOS00LjEgMS40cy0yLjcgMS4xLTMuOSAxLjhjLS42LjMtMS4zLjctMS45IDEtNi44IDMuOS0xMi41IDkuNi0xNi40IDE2LjYtNC4zIDcuNi02LjIgMTYuMi01LjUgMjQuNy4yIDIuOS43IDUuOCAxLjUgOC42LjIuOC41IDEuNS43IDIuMyAwIC4yLjEuMy4yLjUuMi42LjQgMS4yLjcgMS44IDAgLjEuMS4yLjIuNGwuOSAyLjFjMS44IDMuNyA0LjEgNy4yIDYuOCAxMC4yaC0yMi43Yy04IDAtMTUuOC04LjgtMTUuMi0xNS43LjctNy45IDE1LjgtNDcuNSAyNC40LTcwLjEgOC0yMC45IDE4LjktNDIuMyAyNC43LTYzLjMgMy41LTEyLjcgMTUuOS0yOC44IDMyLjEtMzIuOFptMjAuNiAxNTIuOWMwIDEzLjctOSAyNi4zLTIyLjggMzAuMS0yLjQuNy00LjggMS03LjIgMS4xaC0xLjNjLTE0IDAtMjYuMy05LjItMzAuMS0yMi44LS44LTIuOC0xLjItNS42LTEuMi04LjQgMC0xMy43IDktMjYuMyAyMi44LTMwLjEgMi4zLS43IDQuOC0xIDcuMi0xLjFoMS4zYzE0IDAgMjYuMiA5LjMgMzAgMjIuOS44IDIuOCAxLjIgNS42IDEuMiA4LjRabS0xNzUuNCAyOWMtMTEuNC0uMS01OS43IDQuOS01OC4xLTMyIC4yLTE1LjQgOC42LTMzLjkgMTYuOS01Mi44IDguMy0xOC44IDE2LjQtMzcuOSAxNi01NC42LS41LTUuNi01LjctOC0xMC43LTEwLjgtNS0yLjktMTAtNS40LTEwLjEtMTMuOCAwLTcuNSA3LjYtMTMgMTQuNy0xNi4zIDcuMS0zLjMgMTUuNi01LjggMjMtMTEuMiAxMi4zLTguOSAxNC42LTIwLjEgMjAuNC0yOS4yIDUuOS05LjEgMTUuMy0xNi4yIDQyLjEtMTcuMSAxNi44LS41IDI1LjMgMS43IDI4LjkgNy44IDMuNiA2IDIuMyAxNS44LS43IDMwLjQtMS42IDggNS44IDExLjEgMTMuNiAxNC4yIDcuOCAzLjIgMTYuMSA2LjMgMTYuMSAxNC41cy0xMS40IDE1LjUtMjQuNCAyMC40Yy0xMyA1LTI3LjUgOS45LTMzLjggMjAuNC0yLjIgMy43LTguMyAxOS0xMy45IDM0LjMtNS42IDE1LjMtMTAuOCAzMC40LTExIDMzLjgtLjcgMTAuMSA2LjYgMTMuNiAxNC4xIDE2LjkgNy41IDMuMyAxNS4yIDYuMyAxNS4yIDE1LjItLjcgMzIuMi00Mi4zIDI5LjctNTguNiAyOS44Wm0zNiAyNTguOGgtLjhjLTguMyAwLTE1LjYtNS41LTE3LjgtMTMuNi0uNS0xLjctLjctMy4zLS43LTUgMC0yLjEuNC00LjMgMS4xLTYuM3MzNy05MC42IDM3LTkwLjZsMzQuMSAxMy45LTM2LjcgOTAuMmMtMi4yIDUuMi02LjcgOS4xLTEyLjIgMTAuNy0xLjMuNC0yLjQuNy00IC44Wm0xNC40IDExNS4zYy0yLjUgNi4xLTYuNiAxMC40LTEyLjcgMTIuMS0xLjQuNC0yLjkuNi00LjMuN2gtLjhjLTguMyAwLTE1LjEtNS40LTE3LjQtMTMuNC0uNS0xLjctLjctMy40LS43LTUuMSAwLTEuNS4yLTMgLjYtNC41cy4zLTEuMy4zLTEuM2wuNy0yIDgxLjItMTk5LjkgMzQuMSAxMy45LTgxIDE5OS41Wk00MzguNCA0MjBjMi4xLjkgMy44IDIuMyA1IDQuMSAxLjIgMS43IDIuMSAzLjcgMi42IDUuNy40IDEuMy42IDIuNi42IDMuOCAwIDIuMy0uNyA0LjYtMS44IDcuNGwtMjUuNCA2Mi40Yy0xLjQgMy44LTIuOCA2LjUtNC44IDguNi0yIDIuMS00LjYgMy40LTguMSA0LjYtMS41LjUtMyAuNy00LjQuN2gtLjhjLTguNCAwLTE1LjctNS41LTE3LjktMTMuNi0uNS0xLjYtLjctMy4zLS43LTVzLjItMi45LjUtNC4zdi0uMmwuNy0xLjggMTguOC00Ni4zLTM3LjYtMTUuMy00MS4yIDEwMS41LTc1LjctMzAuOC0xLjEtLjUgMjEuMy01Mi42LTk2LjMgNDMuNWMtLjguMy0xLjUuNS0yLjIuNy0xLjQuNC0yLjguNi00LjMuN2gtLjhjLTguMyAwLTE1LjctNS41LTE3LjktMTMuNi0uNS0xLjctLjctMy40LS43LTUgMC03LjMgNC40LTE0LjIgMTEuNC0xNy4yIDI0LjctMTAuNyAxMzUuNS01OSAxNjMuMi03MS4xIDQtMS43IDYuMi0yLjcgNi4zLTIuNyAzLjMtMS40IDYuOC0yLjEgMTAuMi0yLjJoMS4yYzQgMCA3LjIuOCAxMS42IDIuNnM4Ni4zIDM1LjEgODYuMyAzNS4xYy43LjIgMS40LjYgMi4xLjlabTE4OS41LTU4LjRjLTYgMS45LTEyLjYgMy43LTE5LjkgMy4zLTkuNS0uNC0zOS42LTYuOS00Mi02LjktMjYuMSAwLTQwLjMgMTAuOS03MS43IDEwLjlzLTcxLjctMi44LTcxLjctNDAuNiAxMC42LTMzLjEgNDctNTIuNmMyNC0xMi45IDkxLjItMjIuOSAxMDguNi0yNS4zIDMuOS0uNSAzNy4yLTMuMSAzNy4yLTIycy0yMS43LTE0LjktMjcuMi0xNC45Yy0zMy41IDAtNDMuOSAyMi44LTgyLjYgMjIuOHMtMjUuMi0xLjItMjUuNy0xMS45Yy0uOC0xOC42IDQ2LjEtMzUuMyA2MC43LTM4LjMgNTEuMy0xMC42IDEwNS41LTMuMiAxMTYuOSAwIDE2LjcgNC42IDMyIDE2LjggMzIgMzMuOXMtMy45IDIwLTcuMyAyOS45Yy05LjQgMjYtMTkuOSA1MS43LTMxIDc3LjItNS4xIDExLjUtNi4xIDI5LTIzLjMgMzQuNVptMjE2LjYgNy4xYy05LjEgMC0yOS4yIDEuNC0yOS4xLTE0LjcgMC0xMC4zIDM1LjYtODQuNSAzNS42LTEwNC40cy0xNi4yLTIyLjMtMjguMi0yMi4zYy0yOC42IDAtNTEuMSAyMC4yLTYzLjIgNTYuMS02LjcgMjAtMjMuMiA1OS43LTI4IDY2LjktMTAuNSAxNS41LTI3IDE4LjYtNDAuOCAxOC42cy0yOC42LS4yLTI4LjYtMTcuMyAyMy45LTY0LjYgMjcuMy03Mi41YzUuNy0xMy41IDE0LjMtMzcuNiAyMC4xLTUxLjYgMTMuNy0zMy40IDE4LjYtMzguMiA1Mi0zOC43IDEwLjUtLjEgMjguNSA1LjIgNDUgNC44IDIxLjQtLjUgNDYuOS05LjIgNjguNy04LjkgMTUuOC4yIDU4IC43IDU5LjggMzQuMS45IDE2LTI3LjcgNzYuMy0zNC43IDk0LjktMTguMiA0OC40LTE4LjggNTQuOS01NS45IDU0LjlabTE4Ni43LTEzMy42YzEuMSAyNS42IDEyNC41IDguMyAxMTYuMyA2MC42LTE0LjYgOTIuOC0yMjcuNiA4NS45LTIzNi43IDQyLjQtMi4xLTEwLjIgMTguMi0yNiAzNi4zLTI1LjMgMjQuNiAxIDM3LjEgMTcuNiA2My43IDE3LjZzNTEuNS0yLjQgNTMuMS0yMWMuOS0xMC43LTIwLjUtMTQuNi0zNi41LTE2LjMtMTExLjUtMTEuNC03Ny43LTYwLTcwLTY5LjkgNDUuMS01OC4yIDIwOC40LTUwIDIwOC40LTE3LjJzLTI5LjcgMjcuMS00Ni41IDIyLjNjLTI2LjctNy42LTg5LjMtMjAuNS04OC4xIDYuN1ptMjU0LjIgNWMtNi4zIDEwLjEtOS4zIDIyLjEtMTMuNCAzMi42LTguNiAyMi4xLTE4LjggNDMuMi0yNi4xIDY1LjMtOS4xIDI3LjQtMzEgMzEtNDkuNyAzMXMtMzEuNiAwLTMxLjYtMTUuOSA0MC42LTk1IDQwLjYtMTE0LjgtMjIuMy0xNy40LTIyLjMtMjguMyA4LjYtMTQuMiAxNi43LTE3LjhjOS4xLTQgMjIuOS03LjEgMzAuOS0xOC44IDI2LjktMzkuMSA1NC44LTUwLjggOTQuNC01MC44czQ0LjMgMTEuOCA0NC40IDE1LjdjLjcgMjIuOS0zMy43IDI3LjktNDYuNyAzNS44LTEuNiAxLTMuNyAzLjgtMy43IDYuMiAwIDEwLjEgMjIuOCA3LjIgMjIuOCAyMS44cy0zOC4yIDI0LjEtNDEuOSAyNS40Yy01LjIgMi0xMC43IDYuNy0xNC4zIDEyLjRabTEzMy4xIDkxLjdjMzMuMyAwIDU4LjgtMjUuOCA4My44LTI1LjhzMjguMiA0LjQgMjguMiAxNi44LTMwLjEgMjQuNy0zOC45IDI5LjNjLTE5LjMgMTAuMS04Ny44IDI1LjMtMTMzLjggMTAuNS01OS0xOS02NC4yLTU5LjctMzUuMy0xMDcuOSAzMC44LTUxLjMgOTUtNzMuMiAxNTIuOC03My4yczg2LjYgMTEgOTIuMyA1OS45YzEuOCAxNS41LTIgMjkuMi0xNi44IDM3LjYtMTkuOCAxMS4yLTExNi42IDEtMTQ1LjUgNi4xLTExLjEgMi0yNS4xIDYuOS0yNS4xIDIwLjRzMjMuOSAyNi4zIDM4LjMgMjYuM1ptMzExLjgtOTcuNmMtMTguNyA0LjgtMzkuMSA0LjgtNTYuMyAyMC44LTguOCA4LjItMTMgMTkuNi0xNi4xIDI3LjMtNC43IDExLjYtOS41IDIzLjktMTQuMiAzNS42LTUuNyAxNC40LTE1LjMgNDguNC00MC4zIDUwLjYtNiAuNS0zNy4xLjItMzcuMS4yLTggMC0xNS44LTguOC0xNS4yLTE1LjguNy03LjkgMTUuOC00Ny42IDI0LjQtNzAuMSA4LTIwLjkgMTguOS00Mi4zIDI0LjctNjMuMyAzLjUtMTIuNyAxNS45LTI4LjggMzIuMS0zMi44IDEwLjUtMi42IDI2LjItMy4yIDQzLjcgMCAxNC41IDIuNiAxOSA0LjcgMjkuNyA0LjcgOS44IDAgMjIuMi01IDI4LjYtNS4yIDkuMS0uMyAxOS43IDQuMyAyMS4xIDE1LjIgMS43IDEzLjYtOC4zIDI4LjItMjUuMiAzMi42WiIgZmlsbD0iI2Q3ZDdkNyIvPgogIDxwYXRoIGZpbGw9IiNhZjIwMDkiIGQ9Ik0yMjUuMiA3NTV6Ii8+Cjwvc3ZnPgo=);
+                    background-size: 143px 61px;
+                    background-repeat: no-repeat;
+                    background-position: center 20px;
+                }
+/*]]>*/
+</style>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/vendor/jquery.min.js?lm=1767953049"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/ads/tisoomi.com.min.js?lm=1767956103"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/main.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/chosen.ajaxaddition.jquery.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/functions.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/main_desktop.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/chosen.jquery.js?lm=1767953048"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+console.info("%c [TM-ADs] Initialize Ads on domain .com (spieler/profil)", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Tisoomi is active -> add Tisoomi script", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot PerformPlayer (/58778164/d_content_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format PerformPlayer", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot rectangle1 (/58778164/d_side_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format rectangle1", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot rectangle2 (/58778164/d_side_2) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format rectangle2", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot skyscraper (/58778164/d_right_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format skyscraper", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot billboard (/58778164/d_top_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format billboard", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot fullsize_contentad (/58778164/d_bottom_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format fullsize_contentad", "background: #282828; color: #bada55")
+    var oddsServe = function(placement,competition,match,node) {
+        if (!node){
+            var s=document.readyState==='loading'?document.getElementsByTagName('script'):[];
+            node=s.length?s[s.length-1].parentNode:null;
+        }
+        oddsServe.queue.push({contentUnitId:placement,competition:competition,match:match,node:node});
+    }
+    
+    oddsServe.onInit=function(callbacks){
+        if (typeof window.__tcfapi === 'function') {
+            __tcfapi('addEventListener', 2, function(tcdata, success) {
+                let tcf20compatibleString;
+                if(success) {
+                    if (tcdata.eventStatus === 'useractioncomplete') {
+                        tcf20compatibleString = tcdata.tcString;
+                    } else if (tcdata.eventStatus === 'tcloaded') {
+                        tcf20compatibleString = tcdata.tcString;
+                    }
+                    callbacks.setGdprOptions({
+                        gdpr:1,
+                        gdpr_pd:1,
+                        gdpr_consent:tcf20compatibleString,
+                    });
+                }
+            });
+        } else {
+            console.warn('E2: __tcfapi not found');
+        }
+    };
+    oddsServe.options={gdpr_wait:true};
+    oddsServe.queue=[];
+console.info("%c [TM-ADs] Add adslot configuration for PerformPlayer | rectangle1 | rectangle2 | skyscraper | billboard | fullsize_contentad", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Adslots without configuration: ADTAG_CONTENT_BODY_1 | inreadSpecial | profile_above_outbrain | fireplace | skyscraper-left-bound | skyscraperbtf | richmedia | 1by1px", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Register slots with JS vendor lib", "background: #282828; color: #bada55")
+console.warn("%c [TM-ADs] Duplicate placement IDs found: /58778164", "background: #282828; color: #bada55")
+window.addEventListener('load', () => {
+  const offset = window.matchMedia('(max-width: 768px)').matches ? 80 : 120;
+  document.querySelectorAll('[data-sticky]').forEach(node => {
+    const parent = node.parentElement;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) {
+        parent.style.position = 'sticky';
+        parent.style.top = `${offset}px`;
+        parent.style.zIndex = 12000000;
+        setTimeout(() => {
+          parent.style.removeProperty('position');
+          parent.style.removeProperty('top');
+          parent.style.removeProperty('z-index');
+        }, parseInt(node.dataset?.sticky) || 3000);
+        observer.unobserve(parent);
+      }
+    }, { rootMargin: `-${offset}px 0px 0px 0px`, threshold: 1 });
+    observer.observe(parent);
+  });
+});
+PWT = {};
+window.googletag = window.googletag || {cmd: []};
+googletag.cmd.push(() => {
+  window.ad_d_top_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_top_1",
+    [[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90], "fluid"],
+    "d_top_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_side_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_side_1",
+    [[336, 280], [300, 250], [250, 250], "fluid"],
+    "d_side_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_side_2 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_side_2",
+    [[336, 280], [300, 250], [250, 250], "fluid"],
+    "d_side_2"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  window.ad_d_right_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_right_1",
+    [[300, 600], [336, 280], [320, 480], [300, 250], [240, 400], [200, 600], [160, 600], [120, 600]],
+    "d_right_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_content_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_content_1",
+    [[679, 382], [336, 280], [300, 250], [250, 250], [1, 1], "fluid"],
+    "d_content_1"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  window.ad_d_bottom_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_bottom_1",
+    [[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90], "fluid"],
+    "d_bottom_1"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  googletag.pubads().setCentering(true);
+  googletag.pubads().disableInitialLoad();
+  googletag.pubads().setTargeting("cg1", ["spieler"]);
+  googletag.pubads().setTargeting("URL", ["www.transfermarkt.com"]);
+  googletag.enableServices();
+});
+!function(t,$,e,s,i,a,o){$[t]||($[t]={init:function(){_("i",arguments)},fetchBids:function(){_("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]});function _(e,s){$[t]._Q.push([e,s])}}("apstag",window,document,"script","//c.amazon-adsystem.com/aax2/apstag.js"),apstag.init({pubID:"5134",adServer:"googletag"});const initAmazonAdBids=(t,$)=>{($&&"tcloaded"===t.eventStatus||"useractioncomplete"===t.eventStatus)&&apstag.fetchBids(
+  {slots:[
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_top_1",
+      slotID:"d_top_1",
+      sizes:[[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_side_1",
+      slotID:"d_side_1",
+      sizes:[[336, 280], [300, 250], [250, 250]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_side_2",
+      slotID:"d_side_2",
+      sizes:[[336, 280], [300, 250], [250, 250]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_right_1",
+      slotID:"d_right_1",
+      sizes:[[300, 600], [336, 280], [320, 480], [300, 250], [240, 400], [200, 600], [160, 600], [120, 600]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_content_1",
+      slotID:"d_content_1",
+      sizes:[[679, 382], [336, 280], [300, 250], [250, 250], [1, 1]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_bottom_1",
+      slotID:"d_bottom_1",
+      sizes:[[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90]],
+    },
+  ],
+  timeout:2e3},
+  function(t){googletag.cmd.push(function(){apstag.setDisplayBids()})})};
+"function"==typeof window.__tcfapi&&window.__tcfapi("addEventListener",2,initAmazonAdBids);
+
+document.addEventListener("DOMContentLoaded", () => {
+  const closeButtonSticky = document.getElementById("sticky-ad-close-button");
+  if(closeButtonSticky) {
+    closeButtonSticky.addEventListener("touchstart", function(e) {
+      e.preventDefault();
+      var elem = this.parentNode;
+      elem.parentNode.removeChild(elem);
+    }, {passive: false});
+  }
+});
+
+console.info("%c [TM-ADs] Render ad slots js for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Added external ad script https://securepubads.g.doubleclick.net/tag/js/gpt.js for googleadvertising on wettbewerbe_profile_spieler", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Added external ad script https://c.amazon-adsystem.com/aax2/apstag.js for googleadvertising on wettbewerbe_profile_spieler", "background: #282828; color: #bada55")
+/*]]>*/
+</script>
+<title>Lamine Yamal - Player profile 25/26 | Transfermarkt</title>
+    <link rel="apple-touch-icon-precomposed" href="/apple-touch-icon-152x152.png">
+    
+<script type="text/javascript">
+   tmData = {
+       loggedIn : "0",
+       tmTraffic: "0",
+   };
+</script>
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+    let utmVars = {
+        eVar1: urlParams.get('utm_campaign'),
+        eVar6: urlParams.get('utm_source'),
+        eVar24: urlParams.get('utm_medium')
+    };
+    Object.keys(utmVars).forEach((k) => utmVars[k] == null && delete utmVars[k]);
+
+    window.tmAnalyticsDataLayer = window.tmAnalyticsDataLayer || [];
+    window.tmAnalytics = {
+        dimensions: {
+            eVar27: 'Lamine Yamal (937958)',
+			eVar3: 'FC Barcelona (131)',
+			eVar4: 'LaLiga (ES1)',
+			eVar5: 'Spain',
+			eVar10: 'https://www.transfermarkt.com/lamine-yamal/profil/spieler/937958',
+			...utmVars,
+            evar19: window.location.href,
+            eVar35 : '',
+			eVar37 : '',
+    },
+    properties: {
+        prop2: 'statistik',
+		prop3: 'spieler',
+		prop4: 'profil',
+		prop5: '937958',
+		prop11: '937958',
+		prop14: 'statistik_spieler_profil_937958',
+		prop9: window.location.hostname,
+        prop10: window.location.href,
+        prop1 : 'false',
+    },
+    pageDetails: {
+        pageViews: {
+            value: 1
+        },
+        isErrorPage: 'false',
+            isHomepage: 'false',
+            name: 'Lamine Yamal - Player profile 25/26 | Transfermarkt',
+            URL: window.location.href,
+            server: 'prod-tm-web-server-1161'
+    },
+    };
+
+function tmEventForLink(category, aTag, label) {
+    const url = new URL(aTag.href);
+    const link = url.pathname + url.search;
+    tmEvent(category, link, label);
+}
+
+function tmEvent(category, action, label, detail = '') {
+    if (typeof gtag === 'function') {
+        gtag('event',
+            action,
+            {
+                'event_category': category,
+                'event_label': label
+            }
+        );
+    }
+
+    const ev = {
+        event: 'tmEvent',
+        tmEvent: {
+            customDimensions: {
+                eVars: {
+                    ...tmAnalytics.dimensions
+                },
+                props: {
+                    prop6: category,
+                    prop7: action,
+                    prop8: label,
+                    prop17: detail,
+                    ...tmAnalytics.properties
+                }
+            },
+            event1to100: {
+                event7: {
+                    value: 1
+                },
+                event8: null,
+            },
+            session: {
+                web: {
+                    webInteraction: {
+                        linkClicks: {
+                            value: 1
+                        }
+                    },
+                    webPageDetails: {
+                        ...tmAnalytics.pageDetails,
+                        ...{
+                            pageViews: {
+                                value: null
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+     if (!window._satellite) {
+        once = false;
+        window._satellite = { _monitors: [{
+            ruleTriggered: (e) => {
+                if (once) {
+                    return;
+                }
+                once = true;
+                setTimeout(() => {
+                    tmAnalyticsDataLayer.push(ev);
+                    tmAnalyticsDataLayer.push(function (dl) {
+                        const state = dl.getState();
+                    });
+                }, 1);
+            }
+        }] };
+    } else {
+        tmAnalyticsDataLayer.push(ev);
+        tmAnalyticsDataLayer.push(function (dl) {
+            const state = dl.getState();
+        });
+    }
+}
+function tmTrackingAndAds() {
+    if (typeof gtag === 'function') {
+        gtag("event", "page_view", {
+            page_path: "/jsContent" + window.location.pathname
+        });
+    }
+
+    tmAnalyticsDataLayer.push({
+        event: 'tmTrackingAndAds',
+        tmTrackingAndAds: {
+            customDimensions: {
+                eVars: tmAnalytics.dimensions,
+                props: tmAnalytics.properties
+            },
+            event1to100: {
+                event7: null,
+                event8: {
+                    value: 1
+                }
+            },
+            session: {
+                web: {
+                    webInteraction: {
+                        linkClicks: {
+                            value: null
+                        }
+                    },
+                    webPageDetails: {
+                        ...tmAnalytics.pageDetails,
+                        ...{
+                            pageViews: {
+                                value: 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+    tmAnalyticsDataLayer.push(function (dl) {
+        const state = dl.getState();
+    });
+}
+function tmTiming(value, name, event_category, event_label) {
+    console.log('tmTiming', value, name, event_category, event_label);
+}
+
+        !function(e,a,n,t){var i=e.head;if(i){
+            if (a) return;
+            var o=e.createElement("style");
+            o.id="alloy-prehiding",o.innerText=n,i.appendChild(o),setTimeout(function(){o.parentNode&&o.parentNode.removeChild(o)},t)}}
+        (document, document.location.href.indexOf("adobe_authoring_enabled") !== -1, ".personalization-container { opacity: 0 !important }", 3000);
+
+            !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
+                []).push(o),n[o]=function(){var u=arguments;return new Promise(
+                function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
+            (window,["alloy"]);
+</script>
+<tm-consent
+    type="adobe"
+    no-checkbox
+    embed="PHNjcmlwdCBhc3luYyBzcmM9Imh0dHBzOi8vYXNzZXRzLmFkb2JlZHRtLmNvbS83Y2FkY2E5NWRkOWEvY2Q0YWI4ODRkMjMxL2xhdW5jaC0wMTI3MmI0MDBjNjUubWluLmpzIj48L3NjcmlwdD4=">
+</tm-consent>
+
+    <script type="text/javascript" src="https://tmssl.akamaized.net//ads/ads.js"></script>
+    <script type="text/javascript">
+        window.tmGaId = "UA-3816204-13";
+
+        function sendIvwData() {}
+    </script>
+            <link rel="canonical" href="https://www.transfermarkt.com/lamine-yamal/profil/spieler/937958">
+    </head>
+
+<body class="desktop " itemscope itemtype="http://schema.org/WebPage" data-tm-tld="com" data-cmp-layer-id="910164" data-db-name="com-der-zauberzwerg">
+    
+                <tm-domain-note></tm-domain-note>
+        <div id="main">
+                    <button id="back-to-top" title="Nach oben">
+                <svg xmlns="http://www.w3.org/2000/svg" width="17.795" height="10.009" viewBox="0 0 17.795 10.009">
+                    <path id="angle-up" d="M20.683,17.01a1.112,1.112,0,0,1-.786-.326l-7-7-7,7a1.112,1.112,0,1,1-1.573-1.573l7.785-7.785a1.112,1.112,0,0,1,1.573,0l7.785,7.785a1.112,1.112,0,0,1-.786,1.9Z" transform="translate(-4 -7)" fill="#fff"/>
+                </svg>
+            </button>
+            <div class="werbung-skyscraper-left-bound-container">
+                            </div>
+            <div class="werbung-skyscraper-container">
+                <script type="text/javascript">//RWGzztV("skyscraper")</script>
+<div class="ad-placement-note werbung werbung-skyscraper"  data-ad-placement-note="Advertisement">
+  <div id="d_right_1" style="min-height: 600px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_right_1");
+        let has_d_right_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_right_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_right_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_right_1]);
+                has_d_right_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_right_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+            </div>
+
+            <div class="werbung-skyscraperbtf-container">
+                            </div>
+        
+        <div id="tm-overlay"></div>
+
+                    <div class="tm-header__box">
+                <!-- logo  -->
+                <a href="/" class="tm-header__logo" onclick="tmEvent('hauptnavi', '/', 'TM-Logo');">
+                    <img src="https://tmsi.akamaized.net/head/tm_logo_rebrush.svg"
+                         height="62"
+                         width="156"
+                         title="Transfermarkt"
+                         alt="Transfermarkt"
+                    >
+                </a>
+
+                <!-- domainswitcher  -->
+                <div class="domin-swicher">
+                    <tm-domain-switcher
+                        tld="com"
+                        translations='{&quot;chooseYourDomain&quot;:&quot;Choose your domain&quot;}'></tm-domain-switcher>
+                </div>
+
+                <!-- live -->
+                <tm-live-match-count
+                    class="tm-header__live"
+                    auto-request                    content='{&quot;liveMatches&quot;:&quot;Live matches&quot;,&quot;liveMatch&quot;:&quot;Live maches&quot;,&quot;live&quot;:&quot;Live&quot;}'></tm-live-match-count>
+
+                <!-- Search -->
+                                    <div class="tm-header__search " id="schnellsuche-platz">
+                        <form name="schnellsuche" id="schnellsuche" class="tm-header__form" action="/schnellsuche/ergebnis/schnellsuche">
+                            <input type="text" name="query" class="tm-header__input--search-field" onClick="" placeholder="Enter your search term" autocorrect="off" spellcheck="false" value="" />
+                            <button type="submit" value="" class="tm-header__input--search-send" alt="Search">
+                                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="18" viewBox="0 0 18 18">
+                                    <path d="M17.825,16.847 L14.28,13.303 C17.072,9.987 16.756,5.061 13.563,2.13 C10.37,-0.8 5.435,-0.695 2.37,2.37 C-0.695,5.435 -0.8,10.37 2.13,13.563 C5.061,16.756 9.987,17.072 13.303,14.28 L16.847,17.825 C17.121,18.069 17.538,18.057 17.797,17.797 C18.057,17.538 18.069,17.121 17.825,16.847 z M1.418,8.108 C1.417,4.413 4.412,1.417 8.107,1.416 C11.802,1.415 14.798,4.411 14.799,8.106 C14.799,11.801 11.804,14.797 8.108,14.797 C4.414,14.797 1.419,11.803 1.418,8.108 z" fill="#000" />
+                                </svg>
+                            </button>
+                        </form>
+                        <a href="/detailsuche/spielerdetail/suche" title="to detailed player search" id="detailsuche-head" class="tm-header__search-detail">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="18" viewBox="0, 0, 18, 18">
+                                <path d="M3.138,3.558 C3.137,1.593 4.727,0 6.69,0 C8.652,-0 10.243,1.592 10.243,3.556 C10.243,5.521 8.653,7.113 6.69,7.113 C4.729,7.113 3.138,5.522 3.138,3.558 z M8.233,13.187 C8.261,11.778 8.861,10.442 9.893,9.486 C9.967,9.418 9.997,9.315 9.971,9.219 C9.946,9.119 9.863,9.044 9.76,9.03 C9.331,8.938 8.893,8.893 8.454,8.895 L4.906,8.895 C3.583,8.808 2.286,9.298 1.35,10.239 C0.414,11.179 -0.07,12.479 0.021,13.804 C-0.085,14.656 0.209,15.509 0.817,16.114 C1.425,16.72 2.279,17.009 3.13,16.897 L9.266,16.897 C9.372,16.895 9.467,16.831 9.508,16.732 C9.549,16.634 9.527,16.521 9.453,16.444 C8.665,15.544 8.232,14.387 8.236,13.191 z M17.805,17.804 C17.68,17.93 17.511,18 17.334,18 C17.158,18 16.989,17.93 16.864,17.804 L15.237,16.177 C13.686,17.242 11.58,16.949 10.378,15.501 C9.176,14.052 9.274,11.926 10.604,10.594 C11.934,9.263 14.058,9.165 15.505,10.368 C16.952,11.571 17.244,13.68 16.181,15.233 L17.805,16.866 C18.065,17.126 18.065,17.548 17.805,17.808 z M15.484,13.182 C15.484,11.911 14.455,10.881 13.186,10.881 C11.917,10.881 10.888,11.911 10.888,13.182 C10.888,14.452 11.917,15.482 13.186,15.482 C14.455,15.482 15.484,14.452 15.484,13.182 z" fill="#000" />
+                            </svg>
+                        </a>
+                    </div>
+                
+                <!-- login button -->
+                <div class="tm-header__login">
+                    <tm-userbox translations='{&quot;addFavorite&quot;:&quot;Add favourite&quot;,&quot;adminArea&quot;:&quot;Admin area&quot;,&quot;adminTools&quot;:&quot;Admin tools&quot;,&quot;allFavoriteLinkText&quot;:&quot;Go to all my favourite links&quot;,&quot;applyAsModOrDatascout&quot;:&quot;Apply as a moderator or datascout&quot;,&quot;checkAllNews&quot;:&quot;Check all news&quot;,&quot;checkAllRumours&quot;:&quot;Check all rumours&quot;,&quot;chooseYourDomain&quot;:&quot;Choose your domain&quot;,&quot;clickAgain&quot;:&quot;Click again to copy shortlink to your clipboard&quot;,&quot;clubBoard&quot;:&quot;Club forum&quot;,&quot;copied&quot;:&quot;Copied to your clipboard&quot;,&quot;copyLink&quot;:&quot;Link kopieren&quot;,&quot;createAccount&quot;:&quot;Create your account&quot;,&quot;createNewMessage&quot;:&quot;Create a new message&quot;,&quot;createShortlink&quot;:&quot;create a shortlink&quot;,&quot;createShortNews&quot;:&quot;Create memo&quot;,&quot;dashboard&quot;:&quot;Overview&quot;,&quot;dataAdministration&quot;:&quot;Data administration&quot;,&quot;debug&quot;:&quot;Debug&quot;,&quot;deleteAll&quot;:&quot;Delete all&quot;,&quot;deleteConfirm&quot;:&quot;Yes, delete all&quot;,&quot;editText&quot;:&quot;Edit&quot;,&quot;forgotPassword&quot;:&quot;Forgot password?&quot;,&quot;forgotUsername&quot;:&quot;Forgot username?&quot;,&quot;forgotLoginDetails&quot;:&quot;Forgot your login details?&quot;,&quot;forum&quot;:&quot;forum&quot;,&quot;groundhoppingTool&quot;:&quot;Groundhopping Tool&quot;,&quot;lastMatch&quot;:&quot;last match&quot;,&quot;signin&quot;:&quot;Log in&quot;,&quot;login&quot;:&quot;Login&quot;,&quot;logOut&quot;:&quot;Log out&quot;,&quot;manageFavorites&quot;:&quot;Manage favourites&quot;,&quot;marketValue&quot;:&quot;market value&quot;,&quot;matchplan&quot;:&quot;Schedule&quot;,&quot;messages&quot;:&quot;Private messages&quot;,&quot;myClub&quot;:&quot;My club&quot;,&quot;myClubText&quot;:&quot;With a Transfermarkt account you can register your favourite club and find all important information about your club (matches, news, quick links). &quot;,&quot;myDreamTeam&quot;:&quot;My dream team&quot;,&quot;myFavorites&quot;:&quot;My favourites&quot;,&quot;myFavoritesText&quot;:&quot;With a Transfermarkt account, you can save any page as a favourite and then access it with one click.&quot;,&quot;myProfile&quot;:&quot;My profile&quot;,&quot;news&quot;:&quot;News&quot;,&quot;newsAdministration&quot;:&quot;News administration&quot;,&quot;nextMatch&quot;:&quot;next match&quot;,&quot;noNewNotifications&quot;:&quot;No new notifications&quot;,&quot;notifications&quot;:&quot;Notifications&quot;,&quot;notificationsDeletedAutomatically&quot;:&quot;Note: Notifications are automatically deleted after 30 days.&quot;,&quot;notifyDeleteMessage&quot;:&quot;Private messages older than 45 days will be deleted from time to time (except for data scouts and moderators)&quot;,&quot;or&quot;:&quot;or&quot;,&quot;other&quot;:&quot;Miscellaneous&quot;,&quot;overview&quot;:&quot;overview&quot;,&quot;password&quot;:&quot;Password&quot;,&quot;playerRatings&quot;:&quot;Player ratings&quot;,&quot;playerWatchlist&quot;:&quot;Players Watchlist&quot;,&quot;profile&quot;:&quot;Profile&quot;,&quot;progDebug&quot;:&quot;Prog. depanare&quot;,&quot;progProfile&quot;:&quot;Prog. profile&quot;,&quot;registerNow&quot;:&quot;Sign up now&quot;,&quot;rememberMe&quot;:&quot;Remember me&quot;,&quot;removeFavorite&quot;:&quot;Delete favourite&quot;,&quot;rumors&quot;:&quot;Rumours&quot;,&quot;schedule&quot;:&quot;Schedule&quot;,&quot;setting&quot;:&quot;Settings&quot;,&quot;shortlink&quot;:&quot;Shortlink&quot;,&quot;shortLinkCreationError&quot;:&quot;An Error occured creating the shortlink.&quot;,&quot;shortLinkHasBeenCreated&quot;:&quot;Shortlink has been created an was copied to your clipboard&quot;,&quot;shortLinkIsBeingCreated&quot;:&quot;Creating shortlink ...&quot;,&quot;showAllMessages&quot;:&quot;Show all messages&quot;,&quot;totalMarketValue&quot;:&quot;Total market value&quot;,&quot;translation&quot;:&quot;Translation&quot;,&quot;username&quot;:&quot;Username&quot;,&quot;whyRegister&quot;:&quot;Why register?&quot;,&quot;Bitte korrigieren Sie die markierten Felder&quot;:&quot;Bitte korrigieren Sie die markierten Felder&quot;,&quot;mindestensDreiZeichen&quot;:&quot;At least three characters&quot;,&quot;mindestensAchtZeichen&quot;:&quot;At least eight characters&quot;,&quot;pleaseCorrectFields&quot;:&quot;profil&quot;,&quot;minThreeCharacters&quot;:&quot;At least three characters&quot;,&quot;minEightCharacters&quot;:&quot;At least eight characters&quot;,&quot;noAtCharacter&quot;:&quot;The @ character is not allowed in the username&quot;,&quot;agentProfile&quot;:&quot;My Agency Profile&quot;}' page-title="Lamine Yamal - Player profile 25/26 | Transfermarkt" tld="com" agent-profile=""  />
+                </div>
+            </div>
+        
+        
+                        <!-- mobile end -->
+            <nav class="main-navbar">
+                                    <a href="/" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/', 'DISCOVER')">
+                        DISCOVER                    </a>
+                                    <a href="/navigation/transfersundgeruechte" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/transfersundgeruechte', 'TRANSFERS & RUMOURS')">
+                        TRANSFERS & RUMOURS                    </a>
+                                    <a href="/navigation/marktwerte" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/marktwerte', 'MARKET VALUES')">
+                        MARKET VALUES                    </a>
+                                    <a href="/navigation/wettbewerbe" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/wettbewerbe', 'COMPETITIONS')">
+                        COMPETITIONS                    </a>
+                                    <a href="/navigation/statistiken" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/statistiken', 'STATISTICS')">
+                        STATISTICS                    </a>
+                                    <a href="/navigation/community" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/community', 'COMMUNITY')">
+                        COMMUNITY                    </a>
+                                    <a href="/navigation/gaming" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/gaming', 'GAMING')">
+                        GAMING                    </a>
+                                <div class="main-navbar__details">
+                    <div class="hamburger">
+                        <em></em>
+                    </div>
+                    <div class="dropdown-layer"></div>
+                    <div class="main-navbar__dropdown">
+                                                            <div class="recommendation">
+        
+    
+                            <div class="tm-discover__hero-container tm-discover__hero-container-grid tm-discover-container-grid">
+                    
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--two-thirds  "><span class="tm-discover__h2">Recommendations</span><ul class="tm-button-list"><li><a
+                        href="/uefa-champions-league/startseite/wettbewerb/CL"
+                        title="Champions League"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/uefa-champions-league/startseite/wettbewerb/CL' , '1_1', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/cl.png?lm=1626810555"
+                            alt="UEFA Champions League"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/premier-league/startseite/wettbewerb/GB1"
+                        title="Premier League"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/premier-league/startseite/wettbewerb/GB1' , '1_2', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/gb1.png?lm=1521104656"
+                            alt="Premier League"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/laliga/startseite/wettbewerb/ES1"
+                        title="LaLiga"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/laliga/startseite/wettbewerb/ES1' , '1_3', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/es1.png?lm=1725974302"
+                            alt="LaLiga"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/serie-a/startseite/wettbewerb/IT1"
+                        title="Serie A"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/serie-a/startseite/wettbewerb/IT1' , '1_4', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/it1.png?lm=1656073460"
+                            alt="Serie A"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/bundesliga/startseite/wettbewerb/L1"
+                        title="Bundesliga"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/bundesliga/startseite/wettbewerb/L1' , '1_5', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/l1.png?lm=1525905518"
+                            alt="Bundesliga"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/champions-league/startseite/pokalwettbewerb/CL"
+                        title="UEFA Champions League"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/champions-league/startseite/pokalwettbewerb/CL' , '1_6', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/fr1.png?lm=1732280518"
+                            alt="Ligue 1"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li></ul></section>
+                                                                                
+        
+    
+                
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--one-third  tm-button-list__desktop"><span class="tm-discover__h2">Player agents</span><ul class="tm-button-list"><li><a
+                        href="/agent-support/beraterIndex/berater"
+                        title="Agent support"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/agent-support/beraterIndex/berater' , '2_1', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-support.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>support</a></li><li><a
+                        href="/berater/beraterfirmenuebersicht/berater"
+                        title="Agent statistics"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/berater/beraterfirmenuebersicht/berater' , '2_2', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-statistic.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>statistics</a></li><li><a
+                        href="/premium-service/berater"
+                        title="Premium service"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/premium-service/berater' , '2_3', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/premium-service.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Premium<br>service</a></li></ul></section>
+                                                                                
+        
+    
+                
+                                            
+<section class="tm-link-list-container tm-link-list--full ">
+        <div
+        class="tm-link-list-element"
+        role="navigation"
+        aria-label=""
+    >
+                    
+                        
+                                            <ul
+    class="tm-link-list-unordered   recommendation__links"
+>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/neuestetransfers"
+                    title="Latest transfers"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/neuestetransfers' , '3_1','linkList');"
+                >
+                    Latest transfers
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/rumour-mill/detail/forum/154"
+                    title="Rumour Mill"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/rumour-mill/detail/forum/154' , '3_2','linkList');"
+                >
+                    Rumour Mill
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/aktuell/newsarchiv"
+                    title="All news"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/aktuell/newsarchiv' , '3_3','linkList');"
+                >
+                    All news
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/whatsMyValue"
+                    title="What's my value?"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/whatsMyValue' , '3_4','linkList');"
+                >
+                    What's my value?
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/spieler-statistik/wertvollstespieler/marktwertetop"
+                    title="Most valuable players in the world"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/spieler-statistik/wertvollstespieler/marktwertetop' , '3_5','linkList');"
+                >
+                    Most valuable players in the world
+                </a>
+                    </li>
+    </ul>
+                                            <ul
+    class="tm-link-list-unordered   recommendation__links"
+>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/spieler-statistik/wertvollstemannschaften/marktwertetop"
+                    title="Most valuable clubs in the world"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/spieler-statistik/wertvollstemannschaften/marktwertetop' , '3_6','linkList');"
+                >
+                    Most valuable clubs in the world
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/marktwertanalyse/detail/forum/357"
+                    title="Market value analysis"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/marktwertanalyse/detail/forum/357' , '3_7','linkList');"
+                >
+                    Market value analysis
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/vertragslosespieler"
+                    title="Free agents"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/vertragslosespieler' , '3_8','linkList');"
+                >
+                    Free agents
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/endendevertraege"
+                    title="Contracts ending"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/endendevertraege' , '3_9','linkList');"
+                >
+                    Contracts ending
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/betting/"
+                    title="Betting"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/betting/' , '3_10','linkList');"
+                >
+                    Betting
+                </a>
+                    </li>
+    </ul>
+                        </div>
+
+    </section>
+                                                                        
+        
+    
+                
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--full  tm-button-list__mobile"><span class="tm-discover__h2">Player agents</span><ul class="tm-button-list"><li><a
+                        href="/agent-support/beraterIndex/berater"
+                        title="Agent support"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/agent-support/beraterIndex/berater' , '4_1', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-support.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>support</a></li><li><a
+                        href="/berater/beraterfirmenuebersicht/berater"
+                        title="Agent statistics"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/berater/beraterfirmenuebersicht/berater' , '4_2', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-statistic.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>statistics</a></li><li><a
+                        href="/premium-service/berater"
+                        title="Premium service"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/premium-service/berater' , '4_3', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/premium-service.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Premium<br>service</a></li></ul></section>
+                                                                                
+                    </div>
+        
+    </div>
+                                                </div>
+                </div>
+            </nav>
+
+            <div class="quick-select-wrapper">
+    
+    <tm-quick-select defaultCountry="157" defaultCompetition="ES1" defaultClub="131" defaultPlayer="937958" dropdown-visible="" translations='{"home":"Home","country":"Country","competition":"Competition","club":"Club","player":"Player","attack":"Striker","midfield":"Midfielder","defense":"Defender","goalkeeper":"Goalkeeper"}'>
+    </tm-quick-select>
+</div>
+
+            
+        
+        <script type="text/javascript">//RWGzztV("billboard")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-billboard"  data-ad-placement-note="Advertisement">
+  <div id="d_top_1" style="min-width: 1024px; min-height: 250px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_top_1");
+        let has_d_top_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_top_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_top_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_top_1]);
+                has_d_top_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_top_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+
+
+        
+        <main id="tm-main">
+            <tm-consent no-checkbox type="teads" embed=""></tm-consent>
+    <div id="modal-1" class="modal micromodal-slide" aria-hidden="true" tabindex="1">
+        <div class="modal__overlay" tabindex="-1" data-custom-close>
+            <div
+                class="modal__container"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="modal-1-title"
+                data-custom-close
+                >
+                <header class="modal__header">
+                    <button
+                        class="modal__close modal__close--profile-img"
+                        aria-label="Close modal"
+                        data-custom-close
+                        >
+                    </button>
+                </header>
+                <div id="modal-1-content" class="modal__content">
+                                        <img src='https://img.a.transfermarkt.technology/portrait/big/937958-1746563945.jpg?lm=1' alt='Lamine Yamal' title='Lamine Yamal' data-custom-close loading="lazy">
+                </div>
+            </div>
+        </div>
+    </div>
+
+<header class="data-header" itemscope itemtype="https://schema.org/Person">
+                    <div class="data-header__headline-container">
+            <h1 class="data-header__headline-wrapper">
+                                    <span class="data-header__shirt-number">
+                        #10                    </span>
+                                <strong>Lamine Yamal</strong>            </h1>
+                            <tm-watchlist player-id="937958"></tm-watchlist>
+                                </div>
+                    <div class="data-header__badge-container">
+                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="Top goal scorer" class="data-header__success-data">
+                                                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://tmssl.akamaized.net//images/titel/header/5.png?lm=1465908312" title="Top goal scorer" alt="Top goal scorer" class="data-header__success-image lazy lazy" />                                                <span class="data-header__success-number">2</span>
+                    </a>
+                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="TM-Player of the season" class="data-header__success-data">
+                                                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://tmssl.akamaized.net//images/titel/header/256.png?lm=1623075349" title="TM-Player of the season" alt="TM-Player of the season" class="data-header__success-image lazy lazy" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="European champion" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/102.png?lm=1520606997" title="European champion" alt="European champion" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="Spanish champion" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/11.png?lm=1520606997" title="Spanish champion" alt="Spanish champion" class="" />                                                <span class="data-header__success-number">2</span>
+                    </a>
+                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="Spanish cup winner" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/94.png?lm=1520606999" title="Spanish cup winner" alt="Spanish cup winner" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                                    <a href="/lamine-yamal/erfolge/spieler/937958"
+                       title="All titles & victories"
+                       class="data-header__success-more"
+                    >
+                    </a>
+                            </div>
+        
+                    <div class="data-header__box--big">
+                                    <a href="/fc-barcelona/startseite/verein/131" class="data-header__box__club-link">
+                                            <img srcset="
+                            https://tmssl.akamaized.net//images/wappen/normquad/131.png?lm=1406739548 1x,
+                            https://tmssl.akamaized.net//images/wappen/homepageWappen150x150/131.png?lm=1406739548 2x
+                            " alt="FC Barcelona" height="100" width="100" />
+                                        </a>
+                                <div class="data-header__club-info">
+                    <span class="data-header__club" itemprop="affiliation">
+                        <a title="FC Barcelona" href="/fc-barcelona/startseite/verein/131">Barcelona</a>                    </span><br />                    
+                                                                            <span class="data-header__league">
+                                    <a class="data-header__league-link" href="/laliga/startseite/wettbewerb/ES1">
+                                        <img src="https://tmssl.akamaized.net//images/logo/verytiny/es1.png?lm=1725974302" title="LaLiga" alt="LaLiga" class="" />LaLiga                                    </a>
+                                </span>
+                                                                            <span class="data-header__label">League level:
+                                <span class="data-header__content">
+                                    <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />First Tier                                </span>
+                            </span>
+                                                                                                        <span class="data-header__label">Joined: <span class="data-header__content">01/07/2023</span></span>
+                            <span class="data-header__label">Contract expires: <span class="data-header__content">30/06/2031</span></span>
+                                                            </div>
+            </div>
+        
+        <div class="data-header__profile-container">
+                            <div class="modal-trigger" data-custom-open="modal-1" id="fotoauswahlOeffnen" style="cursor:pointer" onclick="tmEvent('spielerprofil','click','profilbild');">
+            
+                                <img src="https://img.a.transfermarkt.technology/portrait/header/937958-1746563945.jpg?lm=1" title="Lamine Yamal" alt="Lamine Yamal" class="data-header__profile-image" height="181" width="139" /><div class="bildquelle"><span title="IMAGO">IMAGO</span></div>
+                                    <span class="modal-trigger-icon">+</span>
+                </div>
+                        </div>
+        <div class="data-header__info-box ">
+            <div class="data-header__details">
+                <ul class="data-header__items">
+                                            <li class="data-header__label">Date of birth/Age:
+                            <span itemprop="birthDate" class="data-header__content">
+                                13/07/2007 (18)                            </span>
+                        </li>
+
+                                                    <li class="data-header__label">Place of birth:
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />                                <span class="data-header__content" itemprop="birthPlace">
+                                    <span class="cp" title="Esplugues de Llobregat">Esplugues de ...</span>                                </span>
+                            </li>
+                        
+                                            <li class="data-header__label">Citizenship:
+                            <span itemprop="nationality" class="data-header__content">
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />                                Spain                            </span>
+                        </li>
+                                    </ul>
+                <ul class="data-header__items">
+                                            <li class="data-header__label">Height:
+                            <span itemprop="height" class="data-header__content">
+                                1,80 m                            </span>
+                        </li>
+                    
+                    <li class="data-header__label">Position:
+                        <span class="data-header__content">
+                            Right Winger                        </span>
+                    </li>
+                    
+                        <li class="data-header__label">Agent:
+                            <span class="data-header__content data-header__content--vertical-aligned">
+                                
+                                    <a onclick="tmEvent(&quot;spielerprofil&quot;, &quot;click&quot;, &quot;berater-header-premium&quot;)" href="/gestifute/beraterfirma/berater/413">Gestifute</a>                                                                            <img class="data-header__verified-logo" src="https://tmsi.akamaized.net/berater/verified_premium_minified.png" alt="verified" title="verified" height="13" width="13">
+                                                                                                </span>
+                        </li>
+
+                                    </ul>
+                <ul class="data-header__items">
+                                            <li for="" class="data-header__label">
+                                                            Current international:
+                                                        <span class="data-header__content">
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen flagge" /><a title="Spain" href="/spanien/startseite/verein/3375">Spain</a>                            </span>
+                        </li>
+                                                    <li class="data-header__label">Caps/Goals:
+                                <a class="data-header__content data-header__content--highlight" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375">23                                </a>/
+                                <a class="data-header__content data-header__content--highlight" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375">6                                </a>
+                            </li>
+                        <li class="data-header__label theme-button">
+    </li>
+                </ul>
+            </div>
+        </div>
+            
+            <div class="data-header__box--small">
+                <a href="/lamine-yamal/marktwertverlauf/spieler/937958" class="data-header__market-value-wrapper"><span class="waehrung">€</span>200.00<span class="waehrung">m</span>                <p class="data-header__last-update">Last update: 12/12/2025</p></a>
+            </div>
+
+            
+    </header>
+<a href="https://www.transfermarkt.com/transfer-focus-what-do-the-traditional-big-six-clubs-need-this-january-/view/news/431862"
+        target="1"
+    class="db mt10"
+        onclick="tmEvent('banner', 'https://www.transfermarkt.com/transfer-focus-what-do-the-traditional-big-six-clubs-need-this-january-/view/news/431862', 'd-day-banner');"
+>
+    <img
+        loading="lazy"
+        src="https://dzjovqk3zamsg.cloudfront.net/big-six-desktop-banner.jpg"
+        width="1034"
+        height="99"
+        alt="deadline-day banner"
+    >
+</a>
+
+<script type="text/javascript">
+    (() => {
+        const cookies = document.cookie
+            .split(';')
+            .map(c => c.trim().split('='))
+            .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+        const isContentPassUser = cookies?._cpauthhint !== undefined;
+        if (isContentPassUser) {
+            const adNodes = document.querySelectorAll('.ad-placement-note');
+            adNodes.forEach(node => node.remove());
+        }
+    })();
+</script><tm-subnavigation
+    controller="spieler"
+    id="937958"
+    season=""
+    section="spieler"
+    style="display: block; margin: 0 5px;">
+</tm-subnavigation>
+<div class="row">
+    <div class="large-8 columns">
+         
+ <tm-player-performance-stage
+    class="box tm-player-performance"
+    style="display: none"
+    competition-id="ES1"
+    player-id="937958"
+    translations='{"performanceDataButton":"Performance Data","galleryButton":"Gallery ","possibleGames":"{spiel} Possible games","possibleGame":"{spiel} Statistics","games":"Appearances","goals":"Goals","assists":"Assists","yellowCard":"Yellow card","yellowCards":"Yellow cards","secondYellowCard":"Second yellow card","secondYellowCards":"Second yellows","redCard":"Red card","redCards":"Red cards","startEleven":"Starting eleven","minutesPlayed":"Minutes","goalsContributed":"Goal participation","detailedStatsLink":"Detailed performance data","cleanSheets":"Clean sheets","goalsConceded":"Goals conceded","performanceSeason":"Performance data :saison","blockedPenaltyPercent":"Penalty Saves","advertisement":"Advertisement","ufl":{"stage":"Football Video Game","button":"PLAY NOW FOR FREE!","available":"Available on","legalLong":"\u00a9 2026, XTEN Limited. All rights reserved. \u201cPlayStation Family Mark\u201d, \u201cPS5 logo\u201d are registered trademarks or trademarks of Sony Interactive Entertainment Inc. PEGI 3. In-game Purchases (Includes Random Items)","legalShort":"\u00a9 2026, XTEN Limited. All rights reserved. PEGI 3. In-game Purchases (Includes Random Items)","parameters":{"pace":"PAC","dribbling":"DRB","shooting":"SHO","defence":"DEF","passing":"PAS","fitness":"FIT","diving":"DIV","reflexes":"RFX","handling":"HAN","speed":"SPD","kicking":"KIC","positioning":"POS"},"roles":{"ST":"ST","LW":"LW","RW":"RW","CAM":"CAM","CM":"CM","CDM":"CDM","LB":"LB","CB":"CB","RB":"RB","GK":"GK"}}}'
+    skeleton-id="svelte-performance-data--195748614"
+ ></tm-player-performance-stage>
+
+ <div class="box" id="svelte-performance-data--195748614">
+    <div class="ssc-square" style="width: 100%; height: 292px; border: 5px solid white;"></div>
+</div>
+
+<div class="box">
+    <h2 class="content-box-headline">Player data </h2>
+    <div class="row collapse">
+        <div class="large-6 large-push-6 columns print">
+                        <div class="weitere-daten-spielerprofil">
+                                    <span class="content-box-subheadline">
+                        Main position                    </span>
+                    <div class="detail-position">
+                        <div class="detail-position__box">
+                                                            <div class="detail-position__inner-box">
+                                    <dl>
+                                        <dt class="detail-position__title">Main position:</dt>
+                                        <dd class="detail-position__position">Right Winger</dd>
+                                                                        </dl>
+                                </div>
+                                <div class="detail-position__position">
+                                    <dl>
+                                        <dt class="detail-position__title">Other position:</dt>
+                                                                                    <dd class="detail-position__position">Left Winger</dd>
+                                                                                    <dd class="detail-position__position">Attacking Midfield</dd>
+                                                                            </dl>
+                                </div>
+                                                    </div>
+
+
+                        <div class="matchfield__campo">
+                            <div class="matchfield__interior"></div>
+                                                            <div class="position position--primary position--12"></div>
+                                                                   <div class="position position--secondary position--11"></div>
+                               
+                                                                 <div class="position position--secondary position--10"></div>
+                                                        </div>
+                    </div>
+                <div class="box tm-player-market-value-development-container">
+    <tm-market-value-development-graph-integrated
+        mobile="false"
+        translations='{&quot;market value&quot;:&quot;Market value&quot;,&quot;team&quot;:&quot;Club&quot;,&quot;age&quot;:&quot;Age&quot;,&quot;resetZoom&quot;:&quot;Vollansicht&quot;,&quot;current&quot;:&quot;Current Market Value\n\n&quot;,&quot;highest&quot;:&quot;Highest market value&quot;,&quot;thread&quot;:&quot;View market value analysis&quot;,&quot;forum&quot;:&quot;Forum&quot;,&quot;details&quot;:&quot;Market value details&quot;,&quot;headline&quot;:&quot;Market value over time&quot;,&quot;lastChange&quot;:&quot;Last update&quot;}'
+        player-id="937958"
+        thread='{&quot;url&quot;:&quot;&quot;,&quot;thread_title&quot;:&quot;&quot;}'
+        details-url="/lamine-yamal/marktwertverlauf/spieler/937958">
+    </tm-market-value-development-graph-integrated>
+</div>
+            </div>
+        </div>
+        <div class="large-6 large-pull-6 columns print spielerdatenundfakten">
+            <span class="content-box-subheadline show-for-small">
+                Facts and data            </span>
+            <div class="info-table info-table--right-space ">
+                                    <span class="info-table__content info-table__content--regular">Full name:</span>
+                    <span class="info-table__content info-table__content--bold">Lamine Yamal Nasraoui Ebana</span>
+                                    <span class="info-table__content info-table__content--regular">Date of birth/Age:</span>
+                    <span class="info-table__content info-table__content--bold">
+
+                                                    <a href="/aktuell/waspassiertheute/aktuell/new/datum/2007-07-13">13/07/2007 (18)</a>                        
+                        </span>
+                                    <span class="info-table__content info-table__content--regular">Place of birth:</span>
+                    <span class="info-table__content info-table__content--bold">
+                         <span title="Barcelona" style="cursor:pointer; color: #1d75a3;">Esplugues de Llobregat&nbsp;&nbsp;<img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen lazy lazy" /></span>                    </span>
+                                                                                                        <span class="info-table__content info-table__content--regular">Height:</span>
+                    <span class="info-table__content info-table__content--bold">1,80&nbsp;m</span>
+                                    <span class="info-table__content info-table__content--regular">Citizenship:</span>
+                    <span class="info-table__content info-table__content--bold">
+                        <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />&nbsp;&nbsp;Spain<br/><img src="https://tmssl.akamaized.net//images/flagge/tiny/8.png?lm=1520611569" title="Equatorial Guinea" alt="Equatorial Guinea" class="flaggenrahmen" />&nbsp;&nbsp;Equatorial Guinea                    </span>
+                                <span class="info-table__content info-table__content--regular">Position:</span>
+                <span class="info-table__content info-table__content--bold">
+                    Attack - Right Winger                </span>
+                                    <span class="info-table__content info-table__content--regular">Foot:</span>
+                    <span class="info-table__content info-table__content--bold">left</span>
+                                                    <span class="info-table__content info-table__content--regular">Player agent:</span>
+                    <span class="info-table__content info-table__content--bold  info-table__content--flex">
+                                                    <a onclick="tmEvent(&quot;spielerprofil&quot;, &quot;click&quot;, &quot;berater-spielerdaten&quot;)" href="/gestifute/beraterfirma/berater/413">Gestifute</a>                                                            <img src="https://tmsi.akamaized.net/berater/verified_premium_minified.png" alt="verified" title="verified" height="13" width="13">
+                                                                        </span>
+                                <span class="info-table__content info-table__content--regular">
+                    Current club:
+                </span>
+                <span class="info-table__content info-table__content--bold info-table__content--flex">
+                    <a href="/fc-barcelona/startseite/verein/131">
+                        <img srcset="https://tmssl.akamaized.net//images/wappen/small/131.png?lm=1406739548 1x,
+                                            https://tmssl.akamaized.net//images/wappen/homepage/131.png?lm=1406739548 2x" alt="FC Barcelona" height="15" width="15" />
+                    </a>
+                    <a title="FC Barcelona" href="/fc-barcelona/startseite/verein/131">FC Barcelona</a>                </span>
+                
+                                            <span class="info-table__content info-table__content--regular">Joined:</span>
+                        <span class="info-table__content info-table__content--bold">
+                            01/07/2023                        </span>
+                        <span class="info-table__content info-table__content--regular">Contract expires:</span>
+                        <span class="info-table__content info-table__content--bold">30/06/2031</span>
+                    
+                                            <span class="info-table__content info-table__content--regular">Last contract extension:</span>
+                        <span class="info-table__content info-table__content--bold">27/05/2025</span>
+                                                        <span class="info-table__content info-table__content--regular">Outfitter:</span>
+                    <span class="info-table__content info-table__content--bold">adidas</span>
+                                    <span class="info-table__content info-table__content--regular">Social-Media:</span>
+                    <span class="info-table__content info-table__content--bold">
+<div class="social-media-toolbar__icons">
+            <a href="http://instagram.com/lamineyamal"
+           target="_blank"
+           title="Instagram"
+           aria-label="Öffnet die Seite von {Instagram} in einem neuen Tab"
+                    >
+
+        <img data-src="https://tmsi.akamaized.net/icons/socialMedia/instagram.svg" class="lazy social" width="15px" height="15px" alt="Social Media Links" />        </a>
+            <a href="http://www.tiktok.com/@lamine.yamal"
+           target="_blank"
+           title="TikTok"
+           aria-label="Öffnet die Seite von {TikTok} in einem neuen Tab"
+                    >
+
+        <img data-src="https://tmsi.akamaized.net/icons/socialMedia/tiktok.svg" class="lazy social" width="15px" height="15px" alt="Social Media Links" />        </a>
+    </div>
+</span>
+                            </div>
+        </div>
+    </div>
+
+
+</div>
+
+<section class="box">
+    <div class="content-box-headline">
+        Transfermarkt Videos    </div>
+    <div class="p10">
+        <tm-consent
+            type="showheroes"
+            no-checkbox
+            embed="PHNjcmlwdCBkYXRhLXdpZD0iYXV0byIgdHlwZT0idGV4dC9qYXZhc2NyaXB0IiBzcmM9Imh0dHBzOi8vY29udGVudC52aXJhbGl6ZS50di9kaXNwbGF5Lz96aWQ9QUFGc20zRHpGdkVlZDZsXyZhbXA7dT1odHRwcyUzQSUyRiUyRnd3dy50cmFuc2Zlcm1hcmt0LmNvbSUyRmxhbWluZS15YW1hbCUyRnByb2ZpbCUyRnNwaWVsZXIlMkY5Mzc5NTgiPjwvc2NyaXB0Pg=="
+        >
+        </tm-consent>
+    </div>
+</section>
+<div class="verletzungsbox">
+    <div class="verletzt ausfall_1">
+    </div>
+    <div class="text">
+        Yellow card suspension - UEFA Champions League<br /><span class="rueckkehr">until 22/01/2026</span>    </div>
+</div>
+<div class="box tm-player-additional-data">
+    <span class="content-box-headline">Further information</span>
+    <div class="content">
+                    Father from Morocco, mother from Equatorial Guinea            <br/><br/>
+                </div>
+</div>
+
+        <tm-player-transfer-history
+            player-id="937958"
+            translations='{&quot;headline&quot;:&quot;Transfer history &quot;,&quot;infotext&quot;:&quot;This is the transfer history of Lamine Yamal. The flag next to each club indicates the country of the club&#039;s league.&quot;,&quot;transferHistory&quot;:&quot;Transfer history&quot;,&quot;upcomingTransfers&quot;:&quot;Upcoming transfer&quot;,&quot;feesum&quot;:&quot;Total transfer fees&quot;,&quot;season&quot;:&quot;Season&quot;,&quot;date&quot;:&quot;Date&quot;,&quot;clubFrom&quot;:&quot;Left&quot;,&quot;clubTo&quot;:&quot;Joined&quot;,&quot;marketValue&quot;:&quot;MV&quot;,&quot;transferFee&quot;:&quot;Fee&quot;,&quot;transferMapLinkText&quot;:&quot;Explore the transfer history on a map&quot;,&quot;loan&quot;:&quot;loan transfer&quot;}'>
+        </tm-player-transfer-history>
+            <div class="box tm-player-additional-data">
+        <h2 class="content-box-headline">Youth clubs</h2>
+        <div class="content">
+            La Torreta (2010-2014), FC Barcelona (2014-2023)
+        </div>
+    </div>
+
+<div class="ad-placement-note ad-placement-background werbung werbung-PerformPlayer"  data-ad-placement-note="Advertisement">
+  <div id="d_content_1" style="min-width: 679px; min-height: 382px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_content_1");
+        let has_d_content_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_content_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_content_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_content_1]);
+                has_d_content_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_content_1"));
+      });
+    </script>
+  </div>
+</div>
+
+
+    <div class="box">
+        <h2 class="content-box-headline">
+            Stats of Lamine Yamal         </h2>
+
+        
+        <tm-player-performance-table
+            player-id="937958"
+            translations='{"games":"Appearances","goals":"Goals","assists":"Assists","minutesPlayed":"Minutes","detailedStatsLink":"Detailed performance data","cleanSheets":"Clean sheets","goalsConceded":"Goals conceded","minutesPerGoal":"Minutes per goal","sum":"Total ","competition":"Competition"}'
+        ></tm-player-performance-table>
+
+        <a
+            href="/lamine-yamal/leistungsdaten/spieler/937958"
+            class="content-link">View full stats</a>
+    </div>
+
+    </div>
+    <div class="large-4 columns">
+        <tm-current-rumors player-id="937958"></tm-current-rumors><script type="text/javascript">//RWGzztV("rectangle1")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-rectangle1"  data-ad-placement-note="Advertisement">
+  <div id="d_side_1" style="min-width: 336px; min-height: 280px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_side_1");
+        let has_d_side_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_side_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_side_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_side_1]);
+                has_d_side_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_side_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+
+        <tm-relevant-news type="player" id="937958"></tm-relevant-news>
+
+        
+
+        
+<tm-matches
+    id="937958"
+    type="player"
+    locale="en"
+    translations='{"headline":"Matches","matchDay":"Matchday","postponed":"postponed"}'
+    limit="25">
+</tm-matches>
+
+        
+<tm-player-national-team-career
+    id="937958"
+    translations="{&quot;widgetTitle&quot;:&quot;National team career&quot;,&quot;shirtNumber&quot;:&quot;#&quot;,&quot;nationalteam&quot;:&quot;National team&quot;,&quot;debut&quot;:&quot;Debut&quot;,&quot;matches&quot;:&quot;Matches&quot;,&quot;goals&quot;:&quot;Goals&quot;,&quot;linkTitle&quot;:&quot;Go to national player profile&quot;,&quot;coachAtDebut&quot;:&quot;Coach at debut&quot;,&quot;ageAtDebut&quot;:&quot;Age at debut&quot;}"
+    page-link></tm-player-national-team-career>
+
+        <tm-image-gallery
+            id="937958"
+            type="player"
+            widgetTitle=Gallery            size="small">
+        </tm-image-gallery>
+
+                    <tm-player-compare headline="Compare Lamine Yamal with ..." player-id="937958" player-full-name="Lamine Yamal" search-player="Search for players" button-text="Compare players"></tm-player-compare>
+
+                <section class="fav-voting">
+        <header class="fav-voting__header">
+            <h2 class="fav-voting__headline">
+                Whom do you prefer?            </h2>
+                            <a href="" class="fav-voting__reload-btn" title="New match" role="button">
+                    <svg width="14" height="15" viewBox="0 0 14 15" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+                        <rect width="14" height="15" fill="url(#pattern0)" />
+                        <defs>
+                            <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+                                <use xlink:href="#image0_757_2" transform="scale(0.0714286 0.0666667)" />
+                            </pattern>
+                            <image id="image0_757_2" width="14" height="15" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAPCAYAAADUFP50AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyZpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDE0IDc5LjE1Njc5NywgMjAxNC8wOC8yMC0wOTo1MzowMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTQgKFdpbmRvd3MpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjZCMjlCNDlGRTQxNjExRTRCQjAyQUVDQTBFMkY0N0FFIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjZCMjlCNEEwRTQxNjExRTRCQjAyQUVDQTBFMkY0N0FFIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6NkIyOUI0OURFNDE2MTFFNEJCMDJBRUNBMEUyRjQ3QUUiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NkIyOUI0OUVFNDE2MTFFNEJCMDJBRUNBMEUyRjQ3QUUiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz66VzloAAACaUlEQVR42mKULV3MgAwq7VWO33nzxfj1t98s/xkYGAU5mP/KC3A9mXj8gQJMTay+1DcWGKfHWyd96/Xn07uP3GP88/cfslnMQCxvLS/031pO8OLJJx/0ll1+zgjW2OmhVTPn9MPmG68+Q1QyMTLICnCB6ddffjJ8+vGb4ejDdwxATfogQ0V5OBgYNx+9JLTo7KO3Jx6/B2vSkeBjcJAXfC4ryD2PlZnpGlCh+srLz+rOPv0Ad4IkHycDy/UXHy7DNOlL8jPEG8sGF225sg7E7/fRsb/x8tOMx59+oIQD0O8MLBdefJYCcQS42BgCNcW3wjSBwIO3XxatvfGK9xeqnxnef/vFwPLw408wR0OYm6Fh3y0fZAXywjyFVfYqRj9//1V5/fWH7duvv4SffP7F/v3PX7AfJbI2XHzBQAKYFqAvwRg0cfN/ThZmBhletp/C3GxvRbk5DrOzMt9hZWE6h+xsELCQFfwPCg85QW4GlksvPjP8BFoNBOxALMXJxhLOxszEkGAg9QjIh2tscFLbMuHEA4gX+NkZmASBgYIMeNlZGII1xD4rCPPEwcT6fHSC1l9/6f0BGCggYCDB+4yFEc39snwcDBrifP3//zNIAxNGy+P3X5PmnXkkeeXFJ5hzGTQlBHRZ/vz7DxZgAToPlCpAEX377dc6UR52hr9AuccfvoFpcMiL8TIEakvWAgPzHcu7bz8Z7BWF/5vLCFw6+ui9PihpgZIYCMMAyFBbecH/3pqSmSVbr8wEiTFWLdn7bfHFZ1wwRfmWCg8efvgm8/7HX2agN/6LcrH+URHhOdt+8I4lspcAAgwAHaQA7YXnQ28AAAAASUVORK5CYII=" />
+                        </defs>
+                    </svg>
+                </a>
+                        </header>
+        <div class="fav-voting__content">
+                            <p class="fav-voting__question fav-voting__question--text-favorite">
+                    Which player do you prefer...                </p>
+                            <div class="fav-voting__wrapper">
+                <a href="/beliebtheit/speichernSpieler?spieler_id_gewinner=937958&spieler_id_verlierer=326330&kontinent=0&land=0&wettbewerb=ES1&verein=131&position=0&marktwert=0&spieler_id_1=937958&lieblingsverein=0" class="fav-voting__link-player fav-voting__link-player--red">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://img.a.transfermarkt.technology/portrait/medium/937958-1746563945.jpg?lm=1" title="Lamine Yamal - source: IMAGO" alt="Lamine Yamal" class="lazy" />                    <div class="fav-voting__name">
+                        Lamine Yamal                    </div>
+                    <div class="fav-voting__club fav-voting__club--left">
+                        <img src="https://tmssl.akamaized.net//images/wappen/kaderquad/131.png?lm=1406739548" title="FC Barcelona" alt="FC Barcelona" class="" />                    </div>
+                </a>
+                <img src="https://tmssl.akamaized.net//images/beliebtheit/versus.png" alt="versus" class="fav-voting__versus-image" width="39" height="35" />
+                <a href="/beliebtheit/speichernSpieler?spieler_id_gewinner=326330&spieler_id_verlierer=937958&kontinent=0&land=0&wettbewerb=ES1&verein=131&position=0&marktwert=0&spieler_id_1=937958&lieblingsverein=0" class="fav-voting__link-player fav-voting__link-player--black">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://img.a.transfermarkt.technology/portrait/medium/326330-1746041680.jpg?lm=1" title="Frenkie de Jong - source: IMAGO" alt="Frenkie de Jong" class="lazy" />                    <div class="fav-voting__name">
+                        Frenkie de Jong                    </div>
+                    <div class="fav-voting__club fav-voting__club--right">
+                        <img src="https://tmssl.akamaized.net//images/wappen/kaderquad/131.png?lm=1406739548" title="FC Barcelona" alt="FC Barcelona" class="" />                    </div>
+                </a>
+            </div>
+        </div>
+    </section>
+    <script type="text/javascript">//RWGzztV("rectangle2")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-rectangle2"  data-ad-placement-note="Advertisement">
+  <div id="d_side_2" style="min-width: 336px; min-height: 280px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_side_2");
+        let has_d_side_2_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_side_2_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_side_2", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_side_2]);
+                has_d_side_2_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_side_2"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+    </div>
+</div>
+    <div class="row">
+        <div class="large-12 columns">
+            <div id="recommender" class="box" >
+    <div class="OUTBRAIN" data-src="" data-widget-id="AR_1" data-ob-template="DE_Transfermarkt.de" ></div>
+    <tm-consent 
+        no-checkbox 
+        type="outbrain" 
+        embed="PHNjcmlwdCB0eXBlPSJ0ZXh0L2phdmFzY3JpcHQiIGFzeW5jPSJhc3luYyIgc3JjPSIvL3dpZGdldHMub3V0YnJhaW4uY29tL291dGJyYWluLmpzIj48L3NjcmlwdD4=">
+    </tm-consent>
+</div>
+        </div>
+    </div>
+
+<div class="ad-placement-note ad-placement-background werbung werbung-fullsize_contentad"  data-ad-placement-note="Advertisement">
+  <div id="d_bottom_1" style="min-width: 1024px; min-height: 250px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_bottom_1");
+        let has_d_bottom_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_bottom_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_bottom_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_bottom_1]);
+                has_d_bottom_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_bottom_1"));
+      });
+    </script>
+  </div>
+</div>
+
+
+        </main>
+        <footer class="tm-footer">
+               <section class="tm-footer__section-quick-links">
+        <strong class="tm-footer__headline tm-footer__headline--large">
+            Quick Links        </strong>
+        <div class="tm-footer__link-wrapper">
+            <a href="/spieler-statistik/wertvollstespieler/marktwertetop"
+               onclick="tmEvent('footer', 'quick_links', '/spieler-statistik/wertvollstespieler')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Most valuable players in the world            </a>
+            <a href="/statistik/neuestetransfers"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/neuestetransfers')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest transfers            </a>
+            <a href="/geruechte/aktuellegeruechte/statistik"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/aktuellegeruechte')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest rumours            </a>
+            <a href="/spieler-statistik/marktwertaenderungen/marktwertetop"
+                onclick="tmEvent('footer', 'quick_links', '/spieler-statistik/marktwertaenderungen/marktwertetop')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest market value updates            </a>
+            <a href="/statistik/weltrangliste"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/weltrangliste')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                FIFA World ranking            </a>
+                        <a href="/betting/"
+                onclick="tmEvent('footer', 'quick_links', '/betting/')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Betting            </a>
+                    </div>
+    </section>
+                <section class="tm-footer__section-involved">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                Be Involved            </strong>
+            <div class="tm-footer__link-wrapper">
+                <a href="/intern/paten"
+                    onclick="tmEvent('footer', 'be_involved', 'mods_data_scouts')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Mods & Data Scouts                </a>
+                <a href="/profil/bewerbung"
+                    onclick="tmEvent('footer', 'be_involved', 'apply_mod_datascout')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Apply as Mod or Datascout                </a>
+                <a href="/intern/elfGebote"
+                    onclick="tmEvent('footer', 'be_involved', '11_commandments')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    11 commandments                </a>
+                <a href="/intern/fehlermelden"
+                    onclick="tmEvent('footer', 'be_involved', 'found_mistake')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Found a mistake?                </a>
+            </div>
+        </section>
+        <section class="tm-footer__section-career">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                Career            </strong>
+            <div class="tm-footer__link-wrapper">
+                                <a href="/intern/tmteam"
+                   class="tm-footer__link tm-footer__link--arrow"
+                   onclick="tmEvent('footer', 'career', 'contact')"
+                >
+                    Contact                </a>
+            </div>
+        </section>
+        <section class="tm-footer__section-about">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                About Us            </strong>
+            <div class="tm-footer__link-wrapper">
+                <a href="/intern/tmteam"
+                   onclick="tmEvent('footer', 'about_us', 'tm_team')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    TM-Team                </a>
+                <a href="/intern/faq"
+                   onclick="tmEvent('footer', 'about_us', 'faq')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    FAQ                </a>
+            </div>
+        </section>
+            <section class="tm-footer__section-social">
+        <strong class="tm-footer__headline
+            ">
+            Social media        </strong>
+        <div class="tm-footer__social-wrapper">
+                        <a href="https://www.instagram.com/transfermarkt_official/"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'instagram')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/instaRebrush.svg"
+                         alt="instagram"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.facebook.com/transfermarkt.global"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'facebook')">
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/fbRebrush.svg"
+                         alt="facebook"
+                         width="25"
+                         height="25"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.whatsapp.com/channel/0029Va6Kevx47XeF0gE99J35"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'whatsapp')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/whatsappRebrush.svg"
+                         alt="whatsapp"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://twitter.com/TMuk_news"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'x')">
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/twitter_rebrush.svg"
+                         alt="x"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.threads.net/@transfermarkt_official"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'threads')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/threadsRebrush.svg"
+                         alt="threads"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.tiktok.com/@transfermarkt"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'tiktok')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/tiktokRebrush.svg"
+                         alt="tiktok"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.youtube.com/@TransfermarktEnglish"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'youtube')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/RebrushYoutube.svg"
+                         alt="youtube"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://t.me/transfermarkt_off"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'telegram')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/telegramRebrush.svg"
+                         alt="telegram"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                        </div>
+    </section>
+                </footer>
+                <div id="menue_overlay"></div>
+    </div>
+    <section class="tm-footer__mobile tm-footer__transfermarkt-info">
+        <section class="tm-footer__section-desktop-width">
+                            <section class="tm-footer__section-company-links">
+                    <span class="tm-footer__headline tm-footer__headline--medium">
+                        Transfermarkt Company Projects                    </span>
+                    <div class="tm-footer__project-wrapper">
+                        <a href="/wahretabelle"
+                           onclick="tmEvent('footer', 'projects', 'wahretabelle')"
+                           class="tm-footer__link"
+                        >
+                            Wahretabelle                        </a>
+                        <a href="https://www.soccerdonna.de/"
+                           onclick="tmEvent('footer', 'projects', 'soccerdonna')"
+                           class="tm-footer__link"
+                        >
+                            Soccerdonna.de                        </a>
+                        <a href="https://scoutastic.com/de/"
+                           onclick="tmEvent('footer', 'projects', 'scoutastic')"
+                           class="tm-footer__link"
+                        >
+                            Scoutastic.com                        </a>
+                    </div>
+                </section>
+                        <section class="tm-footer__section-company-infos">
+                <span class="tm-footer__headline tm-footer__headline--medium">&copy; Transfermarkt <span id="currentYear">2026</span></span>
+                <div class="tm-footer__company-wrapper">
+                    <a
+                    href="/intern/impressum"
+                    class="tm-footer__link tm-footer__link--blue"
+                    onclick="tmEvent('footer', 'officials', 'impressum')"
+                    >
+                        Legal notice                    </a>
+                    <a
+                        href="/intern/web/datenschutz"
+                        class="tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'data_protection')"
+                        >
+                        Data protection                    </a>
+                    <a
+                        href="javascript:void(0)"
+                        class="cmp-link tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'privacy')"
+                    >
+                        Privacy                    </a>
+                    <a
+                        href="javascript:void(0)"
+                        class="revoke-tracking tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'tracking_revocation')"
+                    >
+                        Revoke Tracking                    </a>
+                    <a
+                        href="/intern/anb"
+                        class="tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'general_conduct_of_use')"
+                        >
+                        Site policy                    </a>
+                                    </div>
+            </section>
+        </section>
+    </section>
+    <script type="text/javascript">
+	if(typeof(adet) == "boolean" && adet == false){
+		img_src="/static/singlepictures/jk99hhfsdh209nbnkjldgh90sghfsdlk";
+	} else {
+		img_src="/static/singlepictures/jku90whjlkjbwbta1g4b8h89fh8sgh8d";
+	}
+	var elem = document.createElement("img");
+	document.body.appendChild(elem);
+	elem.src = img_src;
+</script>
+
+            <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                var cnt = document.querySelectorAll('div.large-4.columns').length;
+                if (cnt == 1) {
+                    var sidebarDiv = document.querySelector('div.large-4.columns');
+                    if (sidebarDiv !== null) {
+                        var sidebar = document.getElementById('werbung_recommender_sidebar_wrapper');
+                        sidebarDiv.appendChild(sidebar);
+                        sidebar.style.display = 'block';
+                    }
+                }
+            });
+        </script>
+        <div id="werbung_recommender_sidebar_wrapper" style="display: none;">
+                    </div>
+    <tm-consent type="adition" no-checkbox embed="PHNjcmlwdCBzcmM9Imh0dHBzOi8vY3JlYXRpdmUtY2RuLm9kZHNzZXJ2ZS5jb20vbG9hZGVyLmpzP3B1Ymxpc2hlcj10bSIgYXN5bmM9ImFzeW5jIj48L3NjcmlwdD4="></tm-consent><tm-consent type='adrenalead' no-checkbox embed='PHNjcmlwdCB0eXBlPSd0ZXh0L2phdmFzY3JpcHQnPgogICAgICAgICAgICB3aW5kb3cuX25BZHpxPXdpbmRvdy5fbkFkenF8fFtdOyhmdW5jdGlvbigpewogICAgICAgICAgICB3aW5kb3cuX25BZHpxLnB1c2goWydzZXRJZHMnLCdkNWE0YzFhNzU4Njc4YTUxJ10pOwogICAgICAgICAgICB2YXIgZT0naHR0cHM6Ly9ub3RpZnB1c2guY29tL3NjcmlwdHMvJzsKICAgICAgICAgICAgdmFyIHQ9ZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7CiAgICAgICAgICAgIHQudHlwZT0ndGV4dC9qYXZhc2NyaXB0JzsKICAgICAgICAgICAgdC5kZWZlcj10cnVlOwogICAgICAgICAgICB0LmFzeW5jPXRydWU7CiAgICAgICAgICAgIHQuc3JjPWUrJ25hZHotc2RrLmpzJzsKICAgICAgICAgICAgdmFyIHM9ZG9jdW1lbnQuZ2V0RWxlbWVudHNCeVRhZ05hbWUoJ3NjcmlwdCcpWzBdOwogICAgICAgICAgICBzLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKHQscyl9KSgpOwogICAgICAgIDwvc2NyaXB0Pg=='></tm-consent>    
+        <tm-modal id="tm-modal-revoke-tracking" additionalClose="Close">
+        <div class="tm-modal__headline">Revoke Tracking</div>
+        <p class="tm-modal__text">Sie haben erfolgreich Ihre Einwilligung in die Nutzung von Transfermarkt mit Tracking und Cookies widerrufen. Sie können sich jetzt zwischen dem Contentpass-Abo und der Nutzung mit personalisierter Werbung, Cookies und Tracking entscheiden.</p>
+    </tm-modal>
+
+<tm-consent type="pubmatic" no-checkbox embed="PHNjcmlwdCB0eXBlPSd0ZXh0L2phdmFzY3JpcHQnPgogICAgICAgICAgICAgICAgICAgICAgICB2YXIgUFdUPXt9OwogICAgICAgICAgICAgICAgICAgICAgICB2YXIgZ29vZ2xldGFnID0gZ29vZ2xldGFnIHx8IHt9OwogICAgICAgICAgICAgICAgICAgICAgICBnb29nbGV0YWcuY21kID0gZ29vZ2xldGFnLmNtZCB8fCBbXTsKICAgICAgICAgICAgICAgICAgICAgICAgdmFyIGdwdFJhbiA9IGZhbHNlOwogICAgICAgICAgICAgICAgICAgICAgICBQV1QuanNMb2FkZWQgPSAoKSA9PiB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBsb2FkR1BUKCk7CiAgICAgICAgICAgICAgICAgICAgICAgIH07CiAgICAgICAgICAgICAgICAgICAgICAgIHZhciBsb2FkR1BUID0gZnVuY3Rpb24oKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBpZiAoIWdwdFJhbikgewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdwdFJhbiA9IHRydWU7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIGdhZHMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdzY3JpcHQnKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgdXNlU1NMID0gJ2h0dHBzOicgPT0gZG9jdW1lbnQubG9jYXRpb24ucHJvdG9jb2w7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ2Fkcy5zcmMgPSAodXNlU1NMID8gJ2h0dHBzOicgOiAnaHR0cDonKSArICcvL3NlY3VyZXB1YmFkcy5nLmRvdWJsZWNsaWNrLm5ldC90YWcvanMvZ3B0LmpzJzsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbm9kZSA9IGRvY3VtZW50LmdldEVsZW1lbnRzQnlUYWdOYW1lKCdzY3JpcHQnKVswXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBub2RlLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKGdhZHMsIG5vZGUpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgICAgICB9OwogICAgICAgICAgICAgICAgICAgICAgICAvLyBGYWlsc2FmZSB0byBjYWxsIGdwdAogICAgICAgICAgICAgICAgICAgICAgICBzZXRUaW1lb3V0KGxvYWRHUFQsIDUwMCk7CgogICAgICAgICAgICAgICAgICAgICAgICAoZnVuY3Rpb24oKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgcHVybCA9IHdpbmRvdy5sb2NhdGlvbi5ocmVmOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIHVybCA9ICcvL2Fkcy5wdWJtYXRpYy5jb20vQWRTZXJ2ZXIvanMvcHd0LzE2MzIyOS8xMDEwMyc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgcHJvZmlsZVZlcnNpb25JZCA9ICcnOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgaWYocHVybC5pbmRleE9mKCdwd3R2PScpPjApewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhciByZWdleHAgPSAvcHd0dj0oLio/KSgmfCQpL2c7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbWF0Y2hlcyA9IHJlZ2V4cC5leGVjKHB1cmwpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgaWYobWF0Y2hlcy5sZW5ndGggPj0gMiAmJiBtYXRjaGVzWzFdLmxlbmd0aCA+IDApewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb2ZpbGVWZXJzaW9uSWQgPSAnLycrbWF0Y2hlc1sxXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIHd0YWRzID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy5hc3luYyA9IHRydWU7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy50eXBlID0gJ3RleHQvamF2YXNjcmlwdCc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy5zcmMgPSB1cmwrcHJvZmlsZVZlcnNpb25JZCsnL3B3dC5qcyc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbm9kZSA9IGRvY3VtZW50LmdldEVsZW1lbnRzQnlUYWdOYW1lKCdzY3JpcHQnKVswXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG5vZGUucGFyZW50Tm9kZS5pbnNlcnRCZWZvcmUod3RhZHMsIG5vZGUpOwogICAgICAgICAgICAgICAgICAgICAgICB9KSgpOwogICAgICAgICAgICAgICAgICAgIDwvc2NyaXB0PgogICAgICAgICAgICAgICAgICAgIA=="></tm-consent><tm-consent type="googleadvertising" no-checkbox embed="PHNjcmlwdCAgc3JjPSJodHRwczovL3NlY3VyZXB1YmFkcy5nLmRvdWJsZWNsaWNrLm5ldC90YWcvanMvZ3B0LmpzIiBhc3luYz0iYXN5bmMiPjwvc2NyaXB0Pg=="></tm-consent>
+<tm-consent type="googleadvertising" no-checkbox embed="PHNjcmlwdCAgc3JjPSJodHRwczovL2MuYW1hem9uLWFkc3lzdGVtLmNvbS9hYXgyL2Fwc3RhZy5qcyIgYXN5bmM9ImFzeW5jIj48L3NjcmlwdD4="></tm-consent>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/relevant-news/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-compare/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/watchlist/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/subnavigation/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-performance-stage/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/market-value-development-graph-integrated/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-transfer-history/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-performance-table/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/current-rumors/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/matches-slider/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-national-team-career/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/image-gallery/bundle.js"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/custom/vendors.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/domain-switcher/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/quick-select-bar/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/userbox/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/live-match-count/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/domain-note/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/consent/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/modal/bundle.js"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/custom/tm-skyscraper.min.js?lm=1767953048"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+	var loginUrl='/profil/login';
+	var onlyDE = '';
+	var onlyMobile = '';
+	var onlyTablet = '';
+	var getUserID = '';
+
+oddsServe("e4063cff1119f9fa72b2bff43adea786", -1);
+/*]]>*/
+</script>
+</body>
+
+</html>

--- a/samples/html/yamal_national.html
+++ b/samples/html/yamal_national.html
@@ -1,0 +1,2668 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    
+<script type="text/javascript" data-description="sourcepoint stub code">
+    !function () { var e = function () { var e, t = "__tcfapiLocator", a = [], n = window; for (; n;) { try { if (n.frames[t]) { e = n; break } } catch (e) { } if (n === window.top) break; n = n.parent } e || (!function e() { var a = n.document, r = !!n.frames[t]; if (!r) if (a.body) { var i = a.createElement("iframe"); i.style.cssText = "display:none", i.name = t, a.body.appendChild(i) } else setTimeout(e, 5); return !r }(), n.__tcfapi = function () { for (var e, t = arguments.length, n = new Array(t), r = 0; r < t; r++)n[r] = arguments[r]; if (!n.length) return a; if ("setGdprApplies" === n[0]) n.length > 3 && 2 === parseInt(n[1], 10) && "boolean" == typeof n[3] && (e = n[3], "function" == typeof n[2] && n[2]("set", !0)); else if ("ping" === n[0]) { var i = { gdprApplies: e, cmpLoaded: !1, cmpStatus: "stub" }; "function" == typeof n[2] && n[2](i) } else a.push(n) }, n.addEventListener("message", (function (e) { var t = "string" == typeof e.data, a = {}; try { a = t ? JSON.parse(e.data) : e.data } catch (e) { } var n = a.__tcfapiCall; n && window.__tcfapi(n.command, n.version, (function (a, r) { var i = { __tcfapiReturn: { returnValue: a, success: r, callId: n.callId } }; t && (i = JSON.stringify(i)), e.source.postMessage(i, "*") }), n.parameter) }), !1)) }; "undefined" != typeof module ? module.exports = e : e() }();
+</script>
+<script data-description="sourcepoint configuration">
+window._sp_ = {
+    config: {"accountId":1254,"propertyId":7427,"gdpr":{"consentLanguage":"en","targetingParams":{"acps":"false"}},"baseEndpoint":"https://cdn.privacy-mgmt.com","isSPA":true,"cpPropertyId":"7a84b340"}}
+</script>
+<script src="https://cdn.privacy-mgmt.com/wrapperMessagingWithoutDetection.js" async></script>
+<script type="text/javascript" data-description="contentpass integration">
+    (function() {
+        var cpBaseUrl = 'https://cp.transfermarkt.com';
+        var cpController = cpBaseUrl + '/now.js';
+        var cpPropertyId = '7a84b340';
+
+        !function(C,o,n,t,P,a,s){C['CPObject']=n;C[n]||(C[n]=function(){
+        (C[n].q=C[n].q||[]).push(arguments)});C[n].l=+new Date;a=o.createElement(t);
+        s=o.getElementsByTagName(t)[0];a.src=P;s.parentNode.insertBefore(a,s)}
+        (window,document,'cp','script',cpController);
+
+        !function(C,o,n,t,P){if(!C[n].patched){cp('extension','authenticate');P=C[n].q.push;
+        C[n].q.push=function(a){if(a[0]==='authenticate'){if((o['cookie']||'').indexOf('_cpauthhint=')===-1&&
+        !(C['localStorage']||{})['_cpuser']&&C.location.href.toLowerCase().indexOf('cpauthenticated')===-1){
+        t={isLoggedIn:function(){return false;},hasValidSubscription:function(){return false;}};
+        (typeof a[1]==='function'&&a[1](null,t));C[n].afp=true;P.apply(C[n].q,[['authenticate',null]]);
+        return t;}}P.apply(C[n].q,[a]);}}}
+        (window,document,'cp',false);
+
+        cp('create', cpPropertyId, {
+        baseUrl: cpBaseUrl
+        });
+
+        cp('render', {
+        onFullConsent: function() {
+            console.log('[DEMO] onFullConsent');
+        }
+        })
+    })()
+</script>
+
+<script type="text/javascript" data-description="contentpass sourcepoint fast path">
+(function () {
+    cp('authenticate', function(err, user) {
+        if (err || (!user.isLoggedIn() && !user.hasValidSubscription())) {
+        // console.log('[SPCP] Taking fast path');
+        (function spExecMsg() {
+            if (window._sp_ && window._sp_.executeMessaging) {
+            if (!window._sp_.config.isSPA) {
+                // console.warn('[SPCP] Sourcepoint not in SPA mode!');
+            } else if (window._sp_.version) {
+                // console.log('[SPCP] Sourcepoint already running');
+            } else {
+                // console.log('[SPCP] Starting Sourcepoint');
+                window._sp_.executeMessaging();
+            }
+            } else {
+            // console.log('[SPCP] Sourcepoint not loaded yet. Retrying.');
+            setTimeout(spExecMsg, 10);
+            }
+        })();
+        }
+    });
+    })();
+</script>
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="shortcut icon" sizes="192x192" href="/android-chrome-192x192.png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=no" />
+<meta name="keywords" content="Lamine Yamal,FC Barcelona,LaLiga,Spain" />
+<meta name="description" content="This is the national team page of FC Barcelona player Lamine Yamal. This page contains a statistic about the player&#039;s national team career." />
+<meta property="og:type" content="article" />
+<meta property="og:image" content="https://img.a.transfermarkt.technology/portrait/big/937958-1746563945.jpg?lm=1" />
+<meta property="og:description" content="" />
+<meta property="twitter:image" content="https://img.a.transfermarkt.technology/portrait/big/937958-1746563945.jpg?lm=1" />
+<meta property="og:title" content="Lamine Yamal - National team" />
+<meta property="twitter:title" content="Lamine Yamal - National team" />
+<meta property="og:url" content="https://www.transfermarkt.com/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="de" rel="alternate" href="https://www.transfermarkt.de/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="de-LU" rel="alternate" href="https://www.transfermarkt.de/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="de-AT" rel="alternate" href="https://www.transfermarkt.at/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="de-CH" rel="alternate" href="https://www.transfermarkt.ch/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="tr" rel="alternate" href="https://www.transfermarkt.com.tr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="it-CH" rel="alternate" href="https://www.transfermarkt.it/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="it" rel="alternate" href="https://www.transfermarkt.it/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="pl" rel="alternate" href="https://www.transfermarkt.pl/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="en-GB" rel="alternate" href="https://www.transfermarkt.co.uk/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="en-IE" rel="alternate" href="https://www.transfermarkt.co.uk/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-ES" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-CL" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-VE" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-EC" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-CU" rel="alternate" href="https://www.transfermarkt.es/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="nl" rel="alternate" href="https://www.transfermarkt.nl/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="pt" rel="alternate" href="https://www.transfermarkt.pt/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="ru" rel="alternate" href="https://www.transfermarkt.world/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="fr-CH" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="fr" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="fr-CA" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="fr-CI" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="fr-LU" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="fr-BE" rel="alternate" href="https://www.transfermarkt.fr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="pt-BR" rel="alternate" href="https://www.transfermarkt.com.br/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="en-US" rel="alternate" href="https://www.transfermarkt.us/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="en-CA" rel="alternate" href="https://www.transfermarkt.us/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="en-IN" rel="alternate" href="https://www.transfermarkt.co.in/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="en-ZA" rel="alternate" href="https://www.transfermarkt.co.za/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="x-default" rel="alternate" href="https://www.transfermarkt.com/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="en" rel="alternate" href="https://www.transfermarkt.com/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="nl-BE" rel="alternate" href="https://www.transfermarkt.be/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="ro" rel="alternate" href="https://www.transfermarkt.ro/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="el-GR" rel="alternate" href="https://www.transfermarkt.gr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="ko-KR" rel="alternate" href="https://www.transfermarkt.co.kr/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-AR" rel="alternate" href="https://www.transfermarkt.com.ar/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-MX" rel="alternate" href="https://www.transfermarkt.mx/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-CO" rel="alternate" href="https://www.transfermarkt.co/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="es-PE" rel="alternate" href="https://www.transfermarkt.pe/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="ms" rel="alternate" href="https://www.transfermarkt.my/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="ja" rel="alternate" href="https://www.transfermarkt.jp/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link hreflang="id" rel="alternate" href="https://www.transfermarkt.co.id/lamine-yamal/nationalmannschaft/spieler/937958" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-main.min.css?lm=1767953968" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/stylesheets/main_desktop.css?lm=1767953048" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-discover.min.css?lm=1767953968" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-button-list.min.css?lm=1767953968" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-link-list.min.css?lm=1767953968" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-print.min.css?lm=1767953968" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-chosen.min.css?lm=1767953968" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/stylesheets/main.css?lm=1767953048" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/styles/tm-player-profile.min.css?lm=1767953968" />
+<link rel="stylesheet" type="text/css" href="https://tmssl.akamaized.net/css/jquery-ui-custom.css?lm=1767953048" />
+<style type="text/css">
+/*<![CDATA[*/
+
+                .ad-placement-background {
+                    background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxODk2IDgwNyI+CiAgPHBhdGggZD0iTTEwNTYuMyA1MzIuNGMwLTE3LjEtMTUuMy0yOS4yLTMyLTMzLjktMTEuNS0zLjItNjUuNi0xMC42LTExNi45IDAtMTQuNiAzLTYxLjUgMTkuNy02MC43IDM4LjQuNSAxMC42IDE4LjQgMTEuOSAyNS43IDExLjkgMzguNyAwIDQ5LjEtMjIuNyA4Mi42LTIyLjdzMjcuMi0xLjQgMjcuMiAxNC44LTMzLjMgMjEuNS0zNy4yIDIyYy0xNy40IDIuNC04NC42IDEyLjQtMTA4LjYgMjUuMy0zNi40IDE5LjUtNDcgNDAuNi00NyA1Mi42IDAgMzcuNyA1MC43IDQwLjYgNzEuNyA0MC42IDMxLjQgMCA0NS42LTEwLjkgNzEuNy0xMC45czMyLjYgNi41IDQyIDYuOWM3LjMuMyAxMy45LTEuNCAxOS45LTMuMyAxNy4yLTUuNSAxOC4yLTIzLjEgMjMuMy0zNC42IDExLjEtMjUuNSAyMS42LTUxLjMgMzEuMS03Ny4yIDMuNC05LjkgNy4zLTE5LjggNy4zLTI5LjlabS0xNDQuOCAxMDljLTYuNyAxLjUtOS44IDIuMS0xNy40IDIuNC04LjUuMy0yNi43LTMuNS0yNi43LTE1LjMgMC0yNC40IDYzLjUtMzMuMiA3Mi43LTMzLjIgMTEuMi0uNCAxOC4zIDIuNyAxOC4zIDkuOSAwIDIwLjgtNDQuNiAzNS43LTQ2LjkgMzYuMlpNNzkzLjkgNTA3LjVjLTQ0LjctMjcuOS0xMDcuMiA1LTEzMC41IDUtMzEuOCAwLTMwLjctMTIuOC02NC44LTE1LTY5LTQuMS05MCAxMi4yLTEwNS4yIDEyLjJzLTkuMy04LjMtMjEuNS02LjdjLTEzLjMgMi4yLTE1LjUgNS0xOS4xIDEwLTQuNSA2LjMtNTMuNSAxMzguOC01Ni41IDE0Ni4xLTExLjEgMjYuMyA1NS43IDI5LjUgNzAuOCA4LjcgMzkuNy01NC45IDMwLjktMTE0LjIgODAuOS0xMjMuOSAxMS44LTIuMyAyMi4zLTIuNiAzMC40IDkuMWwuNC44YzcuMiAxMy4zLTUuNCAzOS44LTEzLjggNjAuNS00LjEgMTAtMTYuNiA0Mi43LTE1LjUgNTQgMS45IDIxLjEgNjYuOCAxNC4xIDc1LjYtMi4xIDE5LjMtMzUuNiAyMy4xLTk2LjkgNDQuMS0xMTMuNCAyNS42LTIwIDQ5LjItNC43IDUxLjMgNC41IDQuMiAxOC4yLTEzLjUgNTIuNy0yMyA3Mi44LTEzLjQgMjguNS03LjMgNTEuMSAyNyA1MS4yIDExLjQgMCAyNy00LjQgMzMuNy0xNC4xIDUuNy04LjMgMTQuNS0zMS42IDI3LjQtNjYuNSAxNC4xLTM4LjEgMjkuMi04MCA4LjMtOTMuMVpNMTIzNSA1MTQuMmMtMS40LTExLTEyLTE1LjYtMjEuMS0xNS4yLTYuNC4yLTE4LjggNS4yLTI4LjYgNS4yLTEwLjcgMC0xNS4yLTIuMS0yOS43LTQuNy0xNy41LTMuMi0zMy4yLTIuNi00My43IDAtMTYuMiA0LTI4LjcgMjAtMzIuMSAzMi44LTUuOCAyMS0xNi42IDQyLjQtMjQuNyA2My4zLTguNyAyMi41LTIzLjcgNjIuMi0yNC40IDcwLjEtLjYgNi45IDcuMiAxNS43IDE1LjIgMTUuNyAwIDAgMzEgLjMgMzcuMS0uMiAyNS0yLjIgMzQuNi0zNi4yIDQwLjMtNTAuNiA0LjctMTEuNyA5LjUtMjQgMTQuMi0zNS42IDMuMS03LjcgNy4zLTE5LjEgMTYuMS0yNy4zIDE3LjItMTYgMzcuNi0xNiA1Ni4zLTIwLjggMTYuOS00LjQgMjYuOC0xOSAyNS4yLTMyLjZaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTM3LjcgNDEuOXY3MjEuN2gxODA5LjhWNDEuOUgzNy43Wm0xNzg5LjEgNzAxSDU4LjNWNjIuNWgxNzY4LjV2NjgwLjRaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTE2MzIuNCA0OTUuOGMtNy44LTMuMS0xNS4yLTYuMi0xMy42LTE0LjIgMy0xNC41IDQuMy0yNC4zLjctMzAuNC0zLjYtNi0xMi4yLTguMy0yOC45LTcuOC0yNi43LjgtMzYuMiA3LjktNDIgMTcuMS01LjkgOS4xLTguMiAyMC4zLTIwLjQgMjkuMi03LjUgNS40LTE1LjkgNy45LTIzIDExLjItNy4xIDMuMy0xNC44IDguOC0xNC44IDE2LjMuMSA4LjQgNSAxMC45IDEwLjEgMTMuOCA1IDIuOSAxMC4yIDUuMyAxMC43IDEwLjguMyAxNi42LTcuOCAzNS43LTE2IDU0LjYtOC4zIDE4LjgtMTYuNyAzNy4zLTE2LjkgNTIuOC0xLjYgMzYuOSA0Ni43IDMxLjkgNTguMSAzMiAxNi4yLS4yIDU3LjkgMi40IDU4LjYtMjkuOCAwLTktNy43LTEyLTE1LjItMTUuMi03LjUtMy4zLTE0LjgtNi44LTE0LjEtMTYuOS4zLTMuNCA1LjQtMTguNSAxMS0zMy44IDUuNi0xNS4zIDExLjctMzAuNiAxMy45LTM0LjMgNi4yLTEwLjQgMjAuOC0xNS40IDMzLjgtMjAuNCAxMy01IDI0LjQtMTAgMjQuNC0yMC40cy04LjMtMTEuMy0xNi4xLTE0LjVaTTE0MDcuOSA1MDkuNmMtMTMuOCA1LTc3LjUgNDktODguMiAzNC41LTguMy0xNC4xIDMxLjctNzguMyAyNS44LTkwLjgtNy45LTE2LjYtNDQuMi05LTUyLjUtNS0xNS4xIDcuMy0yMC4xIDI0LjgtMjUuNyAzOC44LTEwLjcgMjYuOC02NS42IDE2Ny44LTY4LjkgMTc4LjMtNS42IDE3LjkgNTQuNyAzMCA3NC44LTE2LjcgNi4zLTE0LjUgMjQuNi0zMi4zIDQwLjktMzIuMyAzMS45IDAgMjYuNyA2My43IDcwLjQgNjQuNyA0LjggMCAyMy41LjUgMzYuNy01LjcgMjMuNC0xMS4xLTI4LTc2LjUtMjgtOTYuNnM4Ni44LTU3LjEgNzkuNi02Ny43Yy05LjItMTMuNS00Ny45LTcuNy02NS0xLjVaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZD0iTTMzMC41IDQxMS43WiIgZmlsbD0iI2I0MTAxZiIvPgogIDxwYXRoIGQ9Ik0xNDI0LjQgMjUyLjZoNDAuM2M0LjIgMCAzMiAwIDMxLjMtMTYuOC0uNi0xMy41LTE4LjctMTcuNS0zMy44LTE3LjYtMTIuOS0uMi01NC4yIDYuNS01NC4yIDIzLjZzNS42IDkuOSAxNi41IDEwLjlaTTU3My40IDI4Mi44Yy05LjIgMC03Mi43IDguOC03Mi43IDMzLjJzMTguMiAxNS43IDI2LjcgMTUuM2M3LjYtLjMgMTAuNy0uOSAxNy40LTIuMyAyLjMtLjUgNDYuOS0xNS40IDQ2LjktMzYuMnMtNy4xLTEwLjMtMTguMy05LjlaIiBmaWxsPSIjZDdkN2Q3Ii8+CiAgPHBhdGggZmlsbD0iI2FmMjAwOSIgZD0iTTM0MC40IDc1NC4xeiIvPgogIDxwYXRoIGQ9Ik0zNzcuMiA3MDYuOGMtNi0yMS42LTI1LjktMzYuMS00OC4zLTM1LjItMy44LjEtNy41LjctMTEuMSAxLjctMjUuNiA3LjItNDAuNiAzMy45LTMzLjQgNTkuNSA2LjEgMjEuNiAyNS45IDM2LjEgNDguMyAzNS4yIDMuOC0uMiA3LjUtLjcgMTEuMS0xLjggMTIuNC0zLjUgMjIuNy0xMS42IDI5LTIyLjggNi4zLTExLjIgNy45LTI0LjIgNC40LTM2LjdabS0xNS40IDMwLjVjLTQuNyA4LjMtMTIuMyAxNC4zLTIxLjQgMTYuOC0yLjcuOC01LjUgMS4yLTguMiAxLjNoLTEuNGMtMTYgMC0yOS45LTEwLjUtMzQuMy0yNi0uOS0zLjItMS4zLTYuNC0xLjMtOS42IDAtMTUuNiAxMC4zLTI5LjkgMjYtMzQuMyAyLjctLjcgNS41LTEuMiA4LjItMS4zaDEuNGMxNS45IDAgMjkuOSAxMC41IDM0LjIgMjYgLjkgMy4yIDEuMyA2LjQgMS4zIDkuNiAwIDYtMS42IDEyLTQuNiAxNy40WiIgZmlsbD0iI2Q3ZDdkNyIvPgogIDxwYXRoIGZpbGw9IiNhZjIwMDkiIGQ9Ik0zMjEuMiA2ODUuNXpNMzMwLjQgMzA4LjV6TTMyMy4yIDMwOS43eiIvPgogIDxwYXRoIGQ9Ik0xODA2LjggODEuOEg3OC4zVjQwNmgxNjZjLTM3LjkgMTYuNS03OC4yIDM0LjEtOTEuOCA0MC0xNC40IDYuMS0yMi4xIDIyLjEtMTcuOSAzNy4yIDMuOCAxMy40IDE2LjEgMjIuOCAzMCAyMi44aDEuMmMyLjQgMCA0LjgtLjUgNy4yLTEuMSAxLS4zIDIuMi0uNiAzLjUtMS4xaC4zYzAtLjEgNjgtMzAuOCA2OC0zMC44bC05LjIgMjIuOEwxOTMuOSA1OThsLS4yLjVjLTIuMiA2LjItMi41IDEyLjgtLjcgMTkgMy44IDEzLjYgMTUuOCAyMi44IDI5LjkgMjIuOGgxLjJjLjcgMCAxLjUgMCAyLjEtLjJsLTM0LjQgODQuN3MtMTMuNyAyOC45IDE0LjUgNDEuMWMzMy4xIDE0LjMgNDMuNi0xOC40IDQzLjYtMTguNGw4MC44LTE5OC44IDQxLjItMTAxLjUgMTQuNCA1LjgtMTQuMiAzNC45LTEgMi43LS4yLjljLTEuMiA1LjEtMS4xIDEwLjUuMyAxNS42IDMuOCAxMy40IDE2LjEgMjIuOCAzMCAyMi44aDEuMWMyIDAgNS0uMyA4LjEtMS40IDEwLjctMy43IDE2LjMtOS4yIDIwLjYtMjAuNWwyNS4zLTYyLjJjMi4yLTUuNCA0LTExLjUgMS43LTE5LjQtMi40LTguNy03LjctMTUuMS0xNS0xOC4xbC0uNC0uMmMtLjUtLjItMS4yLS41LTItLjhsLTMuMi0xLjNoMTM2OS40VjgxLjhaTTM0Mi4zIDE4Ni45YzEwLjUtMi42IDI2LjItMy4yIDQzLjcgMCAxNC41IDIuNiAxOSA0LjcgMjkuNyA0LjcgOS44IDAgMjUuNS00LjggMzEuOS00LjkgOC42LS4xIDIxLjUgMi42IDIxLjUgMTQuM3MtMTUuMSAzMC40LTI5IDMzLjdjLTE4LjggNC42LTM5IDQuMy01Ni4xIDIwLjMtOC44IDguMi0xMyAxOS42LTE2LjEgMjcuMy0zIDcuNS02LjEgMTUuMy05LjIgMjMtNS42LTQuNC0xMi4zLTcuNS0xOS42LTguNy0uNSAwLTEuMS0uMi0xLjctLjNoLS4yYy0uNSAwLTEtLjEtMS41LS4ySDMzMGMtMi42IDAtNS4yLjQtNy43IDEtLjguMi0xLjcuNC0yLjUuNi0xLjQuNC0yLjguOS00LjEgMS40cy0yLjcgMS4xLTMuOSAxLjhjLS42LjMtMS4zLjctMS45IDEtNi44IDMuOS0xMi41IDkuNi0xNi40IDE2LjYtNC4zIDcuNi02LjIgMTYuMi01LjUgMjQuNy4yIDIuOS43IDUuOCAxLjUgOC42LjIuOC41IDEuNS43IDIuMyAwIC4yLjEuMy4yLjUuMi42LjQgMS4yLjcgMS44IDAgLjEuMS4yLjIuNGwuOSAyLjFjMS44IDMuNyA0LjEgNy4yIDYuOCAxMC4yaC0yMi43Yy04IDAtMTUuOC04LjgtMTUuMi0xNS43LjctNy45IDE1LjgtNDcuNSAyNC40LTcwLjEgOC0yMC45IDE4LjktNDIuMyAyNC43LTYzLjMgMy41LTEyLjcgMTUuOS0yOC44IDMyLjEtMzIuOFptMjAuNiAxNTIuOWMwIDEzLjctOSAyNi4zLTIyLjggMzAuMS0yLjQuNy00LjggMS03LjIgMS4xaC0xLjNjLTE0IDAtMjYuMy05LjItMzAuMS0yMi44LS44LTIuOC0xLjItNS42LTEuMi04LjQgMC0xMy43IDktMjYuMyAyMi44LTMwLjEgMi4zLS43IDQuOC0xIDcuMi0xLjFoMS4zYzE0IDAgMjYuMiA5LjMgMzAgMjIuOS44IDIuOCAxLjIgNS42IDEuMiA4LjRabS0xNzUuNCAyOWMtMTEuNC0uMS01OS43IDQuOS01OC4xLTMyIC4yLTE1LjQgOC42LTMzLjkgMTYuOS01Mi44IDguMy0xOC44IDE2LjQtMzcuOSAxNi01NC42LS41LTUuNi01LjctOC0xMC43LTEwLjgtNS0yLjktMTAtNS40LTEwLjEtMTMuOCAwLTcuNSA3LjYtMTMgMTQuNy0xNi4zIDcuMS0zLjMgMTUuNi01LjggMjMtMTEuMiAxMi4zLTguOSAxNC42LTIwLjEgMjAuNC0yOS4yIDUuOS05LjEgMTUuMy0xNi4yIDQyLjEtMTcuMSAxNi44LS41IDI1LjMgMS43IDI4LjkgNy44IDMuNiA2IDIuMyAxNS44LS43IDMwLjQtMS42IDggNS44IDExLjEgMTMuNiAxNC4yIDcuOCAzLjIgMTYuMSA2LjMgMTYuMSAxNC41cy0xMS40IDE1LjUtMjQuNCAyMC40Yy0xMyA1LTI3LjUgOS45LTMzLjggMjAuNC0yLjIgMy43LTguMyAxOS0xMy45IDM0LjMtNS42IDE1LjMtMTAuOCAzMC40LTExIDMzLjgtLjcgMTAuMSA2LjYgMTMuNiAxNC4xIDE2LjkgNy41IDMuMyAxNS4yIDYuMyAxNS4yIDE1LjItLjcgMzIuMi00Mi4zIDI5LjctNTguNiAyOS44Wm0zNiAyNTguOGgtLjhjLTguMyAwLTE1LjYtNS41LTE3LjgtMTMuNi0uNS0xLjctLjctMy4zLS43LTUgMC0yLjEuNC00LjMgMS4xLTYuM3MzNy05MC42IDM3LTkwLjZsMzQuMSAxMy45LTM2LjcgOTAuMmMtMi4yIDUuMi02LjcgOS4xLTEyLjIgMTAuNy0xLjMuNC0yLjQuNy00IC44Wm0xNC40IDExNS4zYy0yLjUgNi4xLTYuNiAxMC40LTEyLjcgMTIuMS0xLjQuNC0yLjkuNi00LjMuN2gtLjhjLTguMyAwLTE1LjEtNS40LTE3LjQtMTMuNC0uNS0xLjctLjctMy40LS43LTUuMSAwLTEuNS4yLTMgLjYtNC41cy4zLTEuMy4zLTEuM2wuNy0yIDgxLjItMTk5LjkgMzQuMSAxMy45LTgxIDE5OS41Wk00MzguNCA0MjBjMi4xLjkgMy44IDIuMyA1IDQuMSAxLjIgMS43IDIuMSAzLjcgMi42IDUuNy40IDEuMy42IDIuNi42IDMuOCAwIDIuMy0uNyA0LjYtMS44IDcuNGwtMjUuNCA2Mi40Yy0xLjQgMy44LTIuOCA2LjUtNC44IDguNi0yIDIuMS00LjYgMy40LTguMSA0LjYtMS41LjUtMyAuNy00LjQuN2gtLjhjLTguNCAwLTE1LjctNS41LTE3LjktMTMuNi0uNS0xLjYtLjctMy4zLS43LTVzLjItMi45LjUtNC4zdi0uMmwuNy0xLjggMTguOC00Ni4zLTM3LjYtMTUuMy00MS4yIDEwMS41LTc1LjctMzAuOC0xLjEtLjUgMjEuMy01Mi42LTk2LjMgNDMuNWMtLjguMy0xLjUuNS0yLjIuNy0xLjQuNC0yLjguNi00LjMuN2gtLjhjLTguMyAwLTE1LjctNS41LTE3LjktMTMuNi0uNS0xLjctLjctMy40LS43LTUgMC03LjMgNC40LTE0LjIgMTEuNC0xNy4yIDI0LjctMTAuNyAxMzUuNS01OSAxNjMuMi03MS4xIDQtMS43IDYuMi0yLjcgNi4zLTIuNyAzLjMtMS40IDYuOC0yLjEgMTAuMi0yLjJoMS4yYzQgMCA3LjIuOCAxMS42IDIuNnM4Ni4zIDM1LjEgODYuMyAzNS4xYy43LjIgMS40LjYgMi4xLjlabTE4OS41LTU4LjRjLTYgMS45LTEyLjYgMy43LTE5LjkgMy4zLTkuNS0uNC0zOS42LTYuOS00Mi02LjktMjYuMSAwLTQwLjMgMTAuOS03MS43IDEwLjlzLTcxLjctMi44LTcxLjctNDAuNiAxMC42LTMzLjEgNDctNTIuNmMyNC0xMi45IDkxLjItMjIuOSAxMDguNi0yNS4zIDMuOS0uNSAzNy4yLTMuMSAzNy4yLTIycy0yMS43LTE0LjktMjcuMi0xNC45Yy0zMy41IDAtNDMuOSAyMi44LTgyLjYgMjIuOHMtMjUuMi0xLjItMjUuNy0xMS45Yy0uOC0xOC42IDQ2LjEtMzUuMyA2MC43LTM4LjMgNTEuMy0xMC42IDEwNS41LTMuMiAxMTYuOSAwIDE2LjcgNC42IDMyIDE2LjggMzIgMzMuOXMtMy45IDIwLTcuMyAyOS45Yy05LjQgMjYtMTkuOSA1MS43LTMxIDc3LjItNS4xIDExLjUtNi4xIDI5LTIzLjMgMzQuNVptMjE2LjYgNy4xYy05LjEgMC0yOS4yIDEuNC0yOS4xLTE0LjcgMC0xMC4zIDM1LjYtODQuNSAzNS42LTEwNC40cy0xNi4yLTIyLjMtMjguMi0yMi4zYy0yOC42IDAtNTEuMSAyMC4yLTYzLjIgNTYuMS02LjcgMjAtMjMuMiA1OS43LTI4IDY2LjktMTAuNSAxNS41LTI3IDE4LjYtNDAuOCAxOC42cy0yOC42LS4yLTI4LjYtMTcuMyAyMy45LTY0LjYgMjcuMy03Mi41YzUuNy0xMy41IDE0LjMtMzcuNiAyMC4xLTUxLjYgMTMuNy0zMy40IDE4LjYtMzguMiA1Mi0zOC43IDEwLjUtLjEgMjguNSA1LjIgNDUgNC44IDIxLjQtLjUgNDYuOS05LjIgNjguNy04LjkgMTUuOC4yIDU4IC43IDU5LjggMzQuMS45IDE2LTI3LjcgNzYuMy0zNC43IDk0LjktMTguMiA0OC40LTE4LjggNTQuOS01NS45IDU0LjlabTE4Ni43LTEzMy42YzEuMSAyNS42IDEyNC41IDguMyAxMTYuMyA2MC42LTE0LjYgOTIuOC0yMjcuNiA4NS45LTIzNi43IDQyLjQtMi4xLTEwLjIgMTguMi0yNiAzNi4zLTI1LjMgMjQuNiAxIDM3LjEgMTcuNiA2My43IDE3LjZzNTEuNS0yLjQgNTMuMS0yMWMuOS0xMC43LTIwLjUtMTQuNi0zNi41LTE2LjMtMTExLjUtMTEuNC03Ny43LTYwLTcwLTY5LjkgNDUuMS01OC4yIDIwOC40LTUwIDIwOC40LTE3LjJzLTI5LjcgMjcuMS00Ni41IDIyLjNjLTI2LjctNy42LTg5LjMtMjAuNS04OC4xIDYuN1ptMjU0LjIgNWMtNi4zIDEwLjEtOS4zIDIyLjEtMTMuNCAzMi42LTguNiAyMi4xLTE4LjggNDMuMi0yNi4xIDY1LjMtOS4xIDI3LjQtMzEgMzEtNDkuNyAzMXMtMzEuNiAwLTMxLjYtMTUuOSA0MC42LTk1IDQwLjYtMTE0LjgtMjIuMy0xNy40LTIyLjMtMjguMyA4LjYtMTQuMiAxNi43LTE3LjhjOS4xLTQgMjIuOS03LjEgMzAuOS0xOC44IDI2LjktMzkuMSA1NC44LTUwLjggOTQuNC01MC44czQ0LjMgMTEuOCA0NC40IDE1LjdjLjcgMjIuOS0zMy43IDI3LjktNDYuNyAzNS44LTEuNiAxLTMuNyAzLjgtMy43IDYuMiAwIDEwLjEgMjIuOCA3LjIgMjIuOCAyMS44cy0zOC4yIDI0LjEtNDEuOSAyNS40Yy01LjIgMi0xMC43IDYuNy0xNC4zIDEyLjRabTEzMy4xIDkxLjdjMzMuMyAwIDU4LjgtMjUuOCA4My44LTI1LjhzMjguMiA0LjQgMjguMiAxNi44LTMwLjEgMjQuNy0zOC45IDI5LjNjLTE5LjMgMTAuMS04Ny44IDI1LjMtMTMzLjggMTAuNS01OS0xOS02NC4yLTU5LjctMzUuMy0xMDcuOSAzMC44LTUxLjMgOTUtNzMuMiAxNTIuOC03My4yczg2LjYgMTEgOTIuMyA1OS45YzEuOCAxNS41LTIgMjkuMi0xNi44IDM3LjYtMTkuOCAxMS4yLTExNi42IDEtMTQ1LjUgNi4xLTExLjEgMi0yNS4xIDYuOS0yNS4xIDIwLjRzMjMuOSAyNi4zIDM4LjMgMjYuM1ptMzExLjgtOTcuNmMtMTguNyA0LjgtMzkuMSA0LjgtNTYuMyAyMC44LTguOCA4LjItMTMgMTkuNi0xNi4xIDI3LjMtNC43IDExLjYtOS41IDIzLjktMTQuMiAzNS42LTUuNyAxNC40LTE1LjMgNDguNC00MC4zIDUwLjYtNiAuNS0zNy4xLjItMzcuMS4yLTggMC0xNS44LTguOC0xNS4yLTE1LjguNy03LjkgMTUuOC00Ny42IDI0LjQtNzAuMSA4LTIwLjkgMTguOS00Mi4zIDI0LjctNjMuMyAzLjUtMTIuNyAxNS45LTI4LjggMzIuMS0zMi44IDEwLjUtMi42IDI2LjItMy4yIDQzLjcgMCAxNC41IDIuNiAxOSA0LjcgMjkuNyA0LjcgOS44IDAgMjIuMi01IDI4LjYtNS4yIDkuMS0uMyAxOS43IDQuMyAyMS4xIDE1LjIgMS43IDEzLjYtOC4zIDI4LjItMjUuMiAzMi42WiIgZmlsbD0iI2Q3ZDdkNyIvPgogIDxwYXRoIGZpbGw9IiNhZjIwMDkiIGQ9Ik0yMjUuMiA3NTV6Ii8+Cjwvc3ZnPgo=);
+                    background-size: 143px 61px;
+                    background-repeat: no-repeat;
+                    background-position: center 20px;
+                }
+/*]]>*/
+</style>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/vendor/jquery.min.js?lm=1767953049"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/assets/b7c5571cf8957553f95f6d9069eaed67/jquery.ba-bbq.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/ads/tisoomi.com.min.js?lm=1767956103"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/jquery-ui-1.10.4.custom.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/main.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/chosen.ajaxaddition.jquery.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/functions.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/main_desktop.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/chosen.jquery.js?lm=1767953048"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+console.info("%c [TM-ADs] Initialize Ads on domain .com (spieler/nationalmannschaft)", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Tisoomi is active -> add Tisoomi script", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot rectangle1 (/58778164/d_side_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format rectangle1", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot rectangle2 (/58778164/d_side_2) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format rectangle2", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot skyscraper (/58778164/d_right_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format skyscraper", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot billboard (/58778164/d_top_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format billboard", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Render slot fullsize_contentad (/58778164/d_bottom_1) for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Wrap ad container with Tisoomi for format fullsize_contentad", "background: #282828; color: #bada55")
+    var oddsServe = function(placement,competition,match,node) {
+        if (!node){
+            var s=document.readyState==='loading'?document.getElementsByTagName('script'):[];
+            node=s.length?s[s.length-1].parentNode:null;
+        }
+        oddsServe.queue.push({contentUnitId:placement,competition:competition,match:match,node:node});
+    }
+    
+    oddsServe.onInit=function(callbacks){
+        if (typeof window.__tcfapi === 'function') {
+            __tcfapi('addEventListener', 2, function(tcdata, success) {
+                let tcf20compatibleString;
+                if(success) {
+                    if (tcdata.eventStatus === 'useractioncomplete') {
+                        tcf20compatibleString = tcdata.tcString;
+                    } else if (tcdata.eventStatus === 'tcloaded') {
+                        tcf20compatibleString = tcdata.tcString;
+                    }
+                    callbacks.setGdprOptions({
+                        gdpr:1,
+                        gdpr_pd:1,
+                        gdpr_consent:tcf20compatibleString,
+                    });
+                }
+            });
+        } else {
+            console.warn('E2: __tcfapi not found');
+        }
+    };
+    oddsServe.options={gdpr_wait:true};
+    oddsServe.queue=[];
+console.info("%c [TM-ADs] Add adslot configuration for rectangle1 | rectangle2 | skyscraper | billboard | fullsize_contentad", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Adslots without configuration: fireplace | skyscraper-left-bound | skyscraperbtf | richmedia | 1by1px", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Register slots with JS vendor lib", "background: #282828; color: #bada55")
+console.warn("%c [TM-ADs] Duplicate placement IDs found: /58778164", "background: #282828; color: #bada55")
+window.addEventListener('load', () => {
+  const offset = window.matchMedia('(max-width: 768px)').matches ? 80 : 120;
+  document.querySelectorAll('[data-sticky]').forEach(node => {
+    const parent = node.parentElement;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (!entry.isIntersecting) {
+        parent.style.position = 'sticky';
+        parent.style.top = `${offset}px`;
+        parent.style.zIndex = 12000000;
+        setTimeout(() => {
+          parent.style.removeProperty('position');
+          parent.style.removeProperty('top');
+          parent.style.removeProperty('z-index');
+        }, parseInt(node.dataset?.sticky) || 3000);
+        observer.unobserve(parent);
+      }
+    }, { rootMargin: `-${offset}px 0px 0px 0px`, threshold: 1 });
+    observer.observe(parent);
+  });
+});
+PWT = {};
+window.googletag = window.googletag || {cmd: []};
+googletag.cmd.push(() => {
+  window.ad_d_top_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_top_1",
+    [[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90], "fluid"],
+    "d_top_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_side_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_side_1",
+    [[336, 280], [300, 250], [250, 250], "fluid"],
+    "d_side_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_side_2 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_side_2",
+    [[336, 280], [300, 250], [250, 250], "fluid"],
+    "d_side_2"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  window.ad_d_right_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_right_1",
+    [[300, 600], [336, 280], [320, 480], [300, 250], [240, 400], [200, 600], [160, 600], [120, 600]],
+    "d_right_1"
+  ) 
+  .setTargeting("loading", "normal")
+  .addService(googletag.pubads());
+  window.ad_d_bottom_1 = googletag.defineSlot(
+    "/58778164/transfermarkt.com/transfermarkt.com_d_bottom_1",
+    [[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90], "fluid"],
+    "d_bottom_1"
+  ) 
+  .setTargeting("loading", "lazy")
+  .addService(googletag.pubads());
+  googletag.pubads().setCentering(true);
+  googletag.pubads().disableInitialLoad();
+  googletag.pubads().setTargeting("cg1", ["spieler"]);
+  googletag.pubads().setTargeting("URL", ["www.transfermarkt.com"]);
+  googletag.enableServices();
+});
+!function(t,$,e,s,i,a,o){$[t]||($[t]={init:function(){_("i",arguments)},fetchBids:function(){_("f",arguments)},setDisplayBids:function(){},targetingKeys:function(){return[]},_Q:[]});function _(e,s){$[t]._Q.push([e,s])}}("apstag",window,document,"script","//c.amazon-adsystem.com/aax2/apstag.js"),apstag.init({pubID:"5134",adServer:"googletag"});const initAmazonAdBids=(t,$)=>{($&&"tcloaded"===t.eventStatus||"useractioncomplete"===t.eventStatus)&&apstag.fetchBids(
+  {slots:[
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_top_1",
+      slotID:"d_top_1",
+      sizes:[[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_side_1",
+      slotID:"d_side_1",
+      sizes:[[336, 280], [300, 250], [250, 250]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_side_2",
+      slotID:"d_side_2",
+      sizes:[[336, 280], [300, 250], [250, 250]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_right_1",
+      slotID:"d_right_1",
+      sizes:[[300, 600], [336, 280], [320, 480], [300, 250], [240, 400], [200, 600], [160, 600], [120, 600]],
+    },
+    {
+      slotName:"/58778164/transfermarkt.com/transfermarkt.com_d_bottom_1",
+      slotID:"d_bottom_1",
+      sizes:[[1024, 250], [970, 250], [980, 90], [970, 90], [960, 90], [950, 90], [800, 250], [750, 100], [750, 200], [728, 90]],
+    },
+  ],
+  timeout:2e3},
+  function(t){googletag.cmd.push(function(){apstag.setDisplayBids()})})};
+"function"==typeof window.__tcfapi&&window.__tcfapi("addEventListener",2,initAmazonAdBids);
+
+document.addEventListener("DOMContentLoaded", () => {
+  const closeButtonSticky = document.getElementById("sticky-ad-close-button");
+  if(closeButtonSticky) {
+    closeButtonSticky.addEventListener("touchstart", function(e) {
+      e.preventDefault();
+      var elem = this.parentNode;
+      elem.parentNode.removeChild(elem);
+    }, {passive: false});
+  }
+});
+
+console.info("%c [TM-ADs] Render ad slots js for google", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Added external ad script https://securepubads.g.doubleclick.net/tag/js/gpt.js for googleadvertising on wettbewerbe_profile_spieler", "background: #282828; color: #bada55")
+console.info("%c [TM-ADs] Added external ad script https://c.amazon-adsystem.com/aax2/apstag.js for googleadvertising on wettbewerbe_profile_spieler", "background: #282828; color: #bada55")
+/*]]>*/
+</script>
+<title>Lamine Yamal - National team | Transfermarkt</title>
+    <link rel="apple-touch-icon-precomposed" href="/apple-touch-icon-152x152.png">
+    
+<script type="text/javascript">
+   tmData = {
+       loggedIn : "0",
+       tmTraffic: "0",
+   };
+</script>
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+    let utmVars = {
+        eVar1: urlParams.get('utm_campaign'),
+        eVar6: urlParams.get('utm_source'),
+        eVar24: urlParams.get('utm_medium')
+    };
+    Object.keys(utmVars).forEach((k) => utmVars[k] == null && delete utmVars[k]);
+
+    window.tmAnalyticsDataLayer = window.tmAnalyticsDataLayer || [];
+    window.tmAnalytics = {
+        dimensions: {
+            eVar27: 'Lamine Yamal (937958)',
+			eVar3: 'FC Barcelona (131)',
+			eVar4: 'LaLiga (ES1)',
+			eVar5: 'Spain',
+			eVar10: 'https://www.transfermarkt.com/lamine-yamal/nationalmannschaft/spieler/937958',
+			...utmVars,
+            evar19: window.location.href,
+            eVar35 : '',
+			eVar37 : '',
+    },
+    properties: {
+        prop2: 'statistik',
+		prop3: 'spieler',
+		prop4: 'nationalmannschaft',
+		prop5: '937958',
+		prop11: '937958',
+		prop14: 'statistik_spieler_nationalmannschaft_937958',
+		prop9: window.location.hostname,
+        prop10: window.location.href,
+        prop1 : 'false',
+    },
+    pageDetails: {
+        pageViews: {
+            value: 1
+        },
+        isErrorPage: 'false',
+            isHomepage: 'false',
+            name: 'Lamine Yamal - National team | Transfermarkt',
+            URL: window.location.href,
+            server: 'web08'
+    },
+    };
+
+function tmEventForLink(category, aTag, label) {
+    const url = new URL(aTag.href);
+    const link = url.pathname + url.search;
+    tmEvent(category, link, label);
+}
+
+function tmEvent(category, action, label, detail = '') {
+    if (typeof gtag === 'function') {
+        gtag('event',
+            action,
+            {
+                'event_category': category,
+                'event_label': label
+            }
+        );
+    }
+
+    const ev = {
+        event: 'tmEvent',
+        tmEvent: {
+            customDimensions: {
+                eVars: {
+                    ...tmAnalytics.dimensions
+                },
+                props: {
+                    prop6: category,
+                    prop7: action,
+                    prop8: label,
+                    prop17: detail,
+                    ...tmAnalytics.properties
+                }
+            },
+            event1to100: {
+                event7: {
+                    value: 1
+                },
+                event8: null,
+            },
+            session: {
+                web: {
+                    webInteraction: {
+                        linkClicks: {
+                            value: 1
+                        }
+                    },
+                    webPageDetails: {
+                        ...tmAnalytics.pageDetails,
+                        ...{
+                            pageViews: {
+                                value: null
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+     if (!window._satellite) {
+        once = false;
+        window._satellite = { _monitors: [{
+            ruleTriggered: (e) => {
+                if (once) {
+                    return;
+                }
+                once = true;
+                setTimeout(() => {
+                    tmAnalyticsDataLayer.push(ev);
+                    tmAnalyticsDataLayer.push(function (dl) {
+                        const state = dl.getState();
+                    });
+                }, 1);
+            }
+        }] };
+    } else {
+        tmAnalyticsDataLayer.push(ev);
+        tmAnalyticsDataLayer.push(function (dl) {
+            const state = dl.getState();
+        });
+    }
+}
+function tmTrackingAndAds() {
+    if (typeof gtag === 'function') {
+        gtag("event", "page_view", {
+            page_path: "/jsContent" + window.location.pathname
+        });
+    }
+
+    tmAnalyticsDataLayer.push({
+        event: 'tmTrackingAndAds',
+        tmTrackingAndAds: {
+            customDimensions: {
+                eVars: tmAnalytics.dimensions,
+                props: tmAnalytics.properties
+            },
+            event1to100: {
+                event7: null,
+                event8: {
+                    value: 1
+                }
+            },
+            session: {
+                web: {
+                    webInteraction: {
+                        linkClicks: {
+                            value: null
+                        }
+                    },
+                    webPageDetails: {
+                        ...tmAnalytics.pageDetails,
+                        ...{
+                            pageViews: {
+                                value: 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+    tmAnalyticsDataLayer.push(function (dl) {
+        const state = dl.getState();
+    });
+}
+function tmTiming(value, name, event_category, event_label) {
+    console.log('tmTiming', value, name, event_category, event_label);
+}
+
+        !function(e,a,n,t){var i=e.head;if(i){
+            if (a) return;
+            var o=e.createElement("style");
+            o.id="alloy-prehiding",o.innerText=n,i.appendChild(o),setTimeout(function(){o.parentNode&&o.parentNode.removeChild(o)},t)}}
+        (document, document.location.href.indexOf("adobe_authoring_enabled") !== -1, ".personalization-container { opacity: 0 !important }", 3000);
+
+            !function(n,o){o.forEach(function(o){n[o]||((n.__alloyNS=n.__alloyNS||
+                []).push(o),n[o]=function(){var u=arguments;return new Promise(
+                function(i,l){n[o].q.push([i,l,u])})},n[o].q=[])})}
+            (window,["alloy"]);
+</script>
+<tm-consent
+    type="adobe"
+    no-checkbox
+    embed="PHNjcmlwdCBhc3luYyBzcmM9Imh0dHBzOi8vYXNzZXRzLmFkb2JlZHRtLmNvbS83Y2FkY2E5NWRkOWEvY2Q0YWI4ODRkMjMxL2xhdW5jaC0wMTI3MmI0MDBjNjUubWluLmpzIj48L3NjcmlwdD4=">
+</tm-consent>
+
+    <script type="text/javascript" src="https://tmssl.akamaized.net//ads/ads.js"></script>
+    <script type="text/javascript">
+        window.tmGaId = "UA-3816204-13";
+
+        function sendIvwData() {}
+    </script>
+            <link rel="canonical" href="https://www.transfermarkt.com/lamine-yamal/nationalmannschaft/spieler/937958">
+    </head>
+
+<body class="desktop " itemscope itemtype="http://schema.org/WebPage" data-tm-tld="com" data-cmp-layer-id="910164" data-db-name="com-der-zauberzwerg">
+    
+                <tm-domain-note></tm-domain-note>
+        <div id="main">
+                    <button id="back-to-top" title="Nach oben">
+                <svg xmlns="http://www.w3.org/2000/svg" width="17.795" height="10.009" viewBox="0 0 17.795 10.009">
+                    <path id="angle-up" d="M20.683,17.01a1.112,1.112,0,0,1-.786-.326l-7-7-7,7a1.112,1.112,0,1,1-1.573-1.573l7.785-7.785a1.112,1.112,0,0,1,1.573,0l7.785,7.785a1.112,1.112,0,0,1-.786,1.9Z" transform="translate(-4 -7)" fill="#fff"/>
+                </svg>
+            </button>
+            <div class="werbung-skyscraper-left-bound-container">
+                            </div>
+            <div class="werbung-skyscraper-container">
+                <script type="text/javascript">//RWGzztV("skyscraper")</script>
+<div class="ad-placement-note werbung werbung-skyscraper"  data-ad-placement-note="Advertisement">
+  <div id="d_right_1" style="min-height: 600px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_right_1");
+        let has_d_right_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_right_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_right_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_right_1]);
+                has_d_right_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_right_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+            </div>
+
+            <div class="werbung-skyscraperbtf-container">
+                            </div>
+        
+        <div id="tm-overlay"></div>
+
+                    <div class="tm-header__box">
+                <!-- logo  -->
+                <a href="/" class="tm-header__logo" onclick="tmEvent('hauptnavi', '/', 'TM-Logo');">
+                    <img src="https://tmsi.akamaized.net/head/tm_logo_rebrush.svg"
+                         height="62"
+                         width="156"
+                         title="Transfermarkt"
+                         alt="Transfermarkt"
+                    >
+                </a>
+
+                <!-- domainswitcher  -->
+                <div class="domin-swicher">
+                    <tm-domain-switcher
+                        tld="com"
+                        translations='{&quot;chooseYourDomain&quot;:&quot;Choose your domain&quot;}'></tm-domain-switcher>
+                </div>
+
+                <!-- live -->
+                <tm-live-match-count
+                    class="tm-header__live"
+                    auto-request                    content='{&quot;liveMatches&quot;:&quot;Live matches&quot;,&quot;liveMatch&quot;:&quot;Live maches&quot;,&quot;live&quot;:&quot;Live&quot;}'></tm-live-match-count>
+
+                <!-- Search -->
+                                    <div class="tm-header__search " id="schnellsuche-platz">
+                        <form name="schnellsuche" id="schnellsuche" class="tm-header__form" action="/schnellsuche/ergebnis/schnellsuche">
+                            <input type="text" name="query" class="tm-header__input--search-field" onClick="" placeholder="Enter your search term" autocorrect="off" spellcheck="false" value="" />
+                            <button type="submit" value="" class="tm-header__input--search-send" alt="Search">
+                                <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="18" viewBox="0 0 18 18">
+                                    <path d="M17.825,16.847 L14.28,13.303 C17.072,9.987 16.756,5.061 13.563,2.13 C10.37,-0.8 5.435,-0.695 2.37,2.37 C-0.695,5.435 -0.8,10.37 2.13,13.563 C5.061,16.756 9.987,17.072 13.303,14.28 L16.847,17.825 C17.121,18.069 17.538,18.057 17.797,17.797 C18.057,17.538 18.069,17.121 17.825,16.847 z M1.418,8.108 C1.417,4.413 4.412,1.417 8.107,1.416 C11.802,1.415 14.798,4.411 14.799,8.106 C14.799,11.801 11.804,14.797 8.108,14.797 C4.414,14.797 1.419,11.803 1.418,8.108 z" fill="#000" />
+                                </svg>
+                            </button>
+                        </form>
+                        <a href="/detailsuche/spielerdetail/suche" title="to detailed player search" id="detailsuche-head" class="tm-header__search-detail">
+                            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18" height="18" viewBox="0, 0, 18, 18">
+                                <path d="M3.138,3.558 C3.137,1.593 4.727,0 6.69,0 C8.652,-0 10.243,1.592 10.243,3.556 C10.243,5.521 8.653,7.113 6.69,7.113 C4.729,7.113 3.138,5.522 3.138,3.558 z M8.233,13.187 C8.261,11.778 8.861,10.442 9.893,9.486 C9.967,9.418 9.997,9.315 9.971,9.219 C9.946,9.119 9.863,9.044 9.76,9.03 C9.331,8.938 8.893,8.893 8.454,8.895 L4.906,8.895 C3.583,8.808 2.286,9.298 1.35,10.239 C0.414,11.179 -0.07,12.479 0.021,13.804 C-0.085,14.656 0.209,15.509 0.817,16.114 C1.425,16.72 2.279,17.009 3.13,16.897 L9.266,16.897 C9.372,16.895 9.467,16.831 9.508,16.732 C9.549,16.634 9.527,16.521 9.453,16.444 C8.665,15.544 8.232,14.387 8.236,13.191 z M17.805,17.804 C17.68,17.93 17.511,18 17.334,18 C17.158,18 16.989,17.93 16.864,17.804 L15.237,16.177 C13.686,17.242 11.58,16.949 10.378,15.501 C9.176,14.052 9.274,11.926 10.604,10.594 C11.934,9.263 14.058,9.165 15.505,10.368 C16.952,11.571 17.244,13.68 16.181,15.233 L17.805,16.866 C18.065,17.126 18.065,17.548 17.805,17.808 z M15.484,13.182 C15.484,11.911 14.455,10.881 13.186,10.881 C11.917,10.881 10.888,11.911 10.888,13.182 C10.888,14.452 11.917,15.482 13.186,15.482 C14.455,15.482 15.484,14.452 15.484,13.182 z" fill="#000" />
+                            </svg>
+                        </a>
+                    </div>
+                
+                <!-- login button -->
+                <div class="tm-header__login">
+                    <tm-userbox translations='{&quot;addFavorite&quot;:&quot;Add favourite&quot;,&quot;adminArea&quot;:&quot;Admin area&quot;,&quot;adminTools&quot;:&quot;Admin tools&quot;,&quot;allFavoriteLinkText&quot;:&quot;Go to all my favourite links&quot;,&quot;applyAsModOrDatascout&quot;:&quot;Apply as a moderator or datascout&quot;,&quot;checkAllNews&quot;:&quot;Check all news&quot;,&quot;checkAllRumours&quot;:&quot;Check all rumours&quot;,&quot;chooseYourDomain&quot;:&quot;Choose your domain&quot;,&quot;clickAgain&quot;:&quot;Click again to copy shortlink to your clipboard&quot;,&quot;clubBoard&quot;:&quot;Club forum&quot;,&quot;copied&quot;:&quot;Copied to your clipboard&quot;,&quot;copyLink&quot;:&quot;Link kopieren&quot;,&quot;createAccount&quot;:&quot;Create your account&quot;,&quot;createNewMessage&quot;:&quot;Create a new message&quot;,&quot;createShortlink&quot;:&quot;create a shortlink&quot;,&quot;createShortNews&quot;:&quot;Create memo&quot;,&quot;dashboard&quot;:&quot;Overview&quot;,&quot;dataAdministration&quot;:&quot;Data administration&quot;,&quot;debug&quot;:&quot;Debug&quot;,&quot;deleteAll&quot;:&quot;Delete all&quot;,&quot;deleteConfirm&quot;:&quot;Yes, delete all&quot;,&quot;editText&quot;:&quot;Edit&quot;,&quot;forgotPassword&quot;:&quot;Forgot password?&quot;,&quot;forgotUsername&quot;:&quot;Forgot username?&quot;,&quot;forgotLoginDetails&quot;:&quot;Forgot your login details?&quot;,&quot;forum&quot;:&quot;forum&quot;,&quot;groundhoppingTool&quot;:&quot;Groundhopping Tool&quot;,&quot;lastMatch&quot;:&quot;last match&quot;,&quot;signin&quot;:&quot;Log in&quot;,&quot;login&quot;:&quot;Login&quot;,&quot;logOut&quot;:&quot;Log out&quot;,&quot;manageFavorites&quot;:&quot;Manage favourites&quot;,&quot;marketValue&quot;:&quot;market value&quot;,&quot;matchplan&quot;:&quot;Schedule&quot;,&quot;messages&quot;:&quot;Private messages&quot;,&quot;myClub&quot;:&quot;My club&quot;,&quot;myClubText&quot;:&quot;With a Transfermarkt account you can register your favourite club and find all important information about your club (matches, news, quick links). &quot;,&quot;myDreamTeam&quot;:&quot;My dream team&quot;,&quot;myFavorites&quot;:&quot;My favourites&quot;,&quot;myFavoritesText&quot;:&quot;With a Transfermarkt account, you can save any page as a favourite and then access it with one click.&quot;,&quot;myProfile&quot;:&quot;My profile&quot;,&quot;news&quot;:&quot;News&quot;,&quot;newsAdministration&quot;:&quot;News administration&quot;,&quot;nextMatch&quot;:&quot;next match&quot;,&quot;noNewNotifications&quot;:&quot;No new notifications&quot;,&quot;notifications&quot;:&quot;Notifications&quot;,&quot;notificationsDeletedAutomatically&quot;:&quot;Note: Notifications are automatically deleted after 30 days.&quot;,&quot;notifyDeleteMessage&quot;:&quot;Private messages older than 45 days will be deleted from time to time (except for data scouts and moderators)&quot;,&quot;or&quot;:&quot;or&quot;,&quot;other&quot;:&quot;Miscellaneous&quot;,&quot;overview&quot;:&quot;overview&quot;,&quot;password&quot;:&quot;Password&quot;,&quot;playerRatings&quot;:&quot;Player ratings&quot;,&quot;playerWatchlist&quot;:&quot;Players Watchlist&quot;,&quot;profile&quot;:&quot;Profile&quot;,&quot;progDebug&quot;:&quot;Prog. depanare&quot;,&quot;progProfile&quot;:&quot;Prog. profile&quot;,&quot;registerNow&quot;:&quot;Sign up now&quot;,&quot;rememberMe&quot;:&quot;Remember me&quot;,&quot;removeFavorite&quot;:&quot;Delete favourite&quot;,&quot;rumors&quot;:&quot;Rumours&quot;,&quot;schedule&quot;:&quot;Schedule&quot;,&quot;setting&quot;:&quot;Settings&quot;,&quot;shortlink&quot;:&quot;Shortlink&quot;,&quot;shortLinkCreationError&quot;:&quot;An Error occured creating the shortlink.&quot;,&quot;shortLinkHasBeenCreated&quot;:&quot;Shortlink has been created an was copied to your clipboard&quot;,&quot;shortLinkIsBeingCreated&quot;:&quot;Creating shortlink ...&quot;,&quot;showAllMessages&quot;:&quot;Show all messages&quot;,&quot;totalMarketValue&quot;:&quot;Total market value&quot;,&quot;translation&quot;:&quot;Translation&quot;,&quot;username&quot;:&quot;Username&quot;,&quot;whyRegister&quot;:&quot;Why register?&quot;,&quot;Bitte korrigieren Sie die markierten Felder&quot;:&quot;Bitte korrigieren Sie die markierten Felder&quot;,&quot;mindestensDreiZeichen&quot;:&quot;At least three characters&quot;,&quot;mindestensAchtZeichen&quot;:&quot;At least eight characters&quot;,&quot;pleaseCorrectFields&quot;:&quot;profil&quot;,&quot;minThreeCharacters&quot;:&quot;At least three characters&quot;,&quot;minEightCharacters&quot;:&quot;At least eight characters&quot;,&quot;noAtCharacter&quot;:&quot;The @ character is not allowed in the username&quot;,&quot;agentProfile&quot;:&quot;My Agency Profile&quot;}' page-title="Lamine Yamal - National team | Transfermarkt" tld="com" agent-profile=""  />
+                </div>
+            </div>
+        
+        
+                        <!-- mobile end -->
+            <nav class="main-navbar">
+                                    <a href="/" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/', 'DISCOVER')">
+                        DISCOVER                    </a>
+                                    <a href="/navigation/transfersundgeruechte" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/transfersundgeruechte', 'TRANSFERS & RUMOURS')">
+                        TRANSFERS & RUMOURS                    </a>
+                                    <a href="/navigation/marktwerte" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/marktwerte', 'MARKET VALUES')">
+                        MARKET VALUES                    </a>
+                                    <a href="/navigation/wettbewerbe" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/wettbewerbe', 'COMPETITIONS')">
+                        COMPETITIONS                    </a>
+                                    <a href="/navigation/statistiken" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/statistiken', 'STATISTICS')">
+                        STATISTICS                    </a>
+                                    <a href="/navigation/community" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/community', 'COMMUNITY')">
+                        COMMUNITY                    </a>
+                                    <a href="/navigation/gaming" class="main-navbar__lp-link " onclick="tmEvent('hauptnavi', '/navigation/gaming', 'GAMING')">
+                        GAMING                    </a>
+                                <div class="main-navbar__details">
+                    <div class="hamburger">
+                        <em></em>
+                    </div>
+                    <div class="dropdown-layer"></div>
+                    <div class="main-navbar__dropdown">
+                                                            <div class="recommendation">
+        
+    
+                            <div class="tm-discover__hero-container tm-discover__hero-container-grid tm-discover-container-grid">
+                    
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--two-thirds  "><span class="tm-discover__h2">Recommendations</span><ul class="tm-button-list"><li><a
+                        href="/uefa-champions-league/startseite/wettbewerb/CL"
+                        title="Champions League"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/uefa-champions-league/startseite/wettbewerb/CL' , '1_1', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/cl.png?lm=1626810555"
+                            alt="UEFA Champions League"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/premier-league/startseite/wettbewerb/GB1"
+                        title="Premier League"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/premier-league/startseite/wettbewerb/GB1' , '1_2', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/gb1.png?lm=1521104656"
+                            alt="Premier League"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/laliga/startseite/wettbewerb/ES1"
+                        title="LaLiga"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/laliga/startseite/wettbewerb/ES1' , '1_3', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/es1.png?lm=1725974302"
+                            alt="LaLiga"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/serie-a/startseite/wettbewerb/IT1"
+                        title="Serie A"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/serie-a/startseite/wettbewerb/IT1' , '1_4', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/it1.png?lm=1656073460"
+                            alt="Serie A"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/bundesliga/startseite/wettbewerb/L1"
+                        title="Bundesliga"
+                        target=""
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/bundesliga/startseite/wettbewerb/L1' , '1_5', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/l1.png?lm=1525905518"
+                            alt="Bundesliga"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li><li><a
+                        href="/champions-league/startseite/pokalwettbewerb/CL"
+                        title="UEFA Champions League"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big "
+                        onclick="tmEvent('recommendations_recommendation', '/champions-league/startseite/pokalwettbewerb/CL' , '1_6', 'buttonList');"
+                    ><img
+                            src="https://tmssl.akamaized.net//images/logo/homepageWappen150x150/fr1.png?lm=1732280518"
+                            alt="Ligue 1"
+                            class="tm-button-list__image tm-button-list__image--big 1"
+                            width="54"
+                            height="36"
+                        ></a></li></ul></section>
+                                                                                
+        
+    
+                
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--one-third  tm-button-list__desktop"><span class="tm-discover__h2">Player agents</span><ul class="tm-button-list"><li><a
+                        href="/agent-support/beraterIndex/berater"
+                        title="Agent support"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/agent-support/beraterIndex/berater' , '2_1', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-support.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>support</a></li><li><a
+                        href="/berater/beraterfirmenuebersicht/berater"
+                        title="Agent statistics"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/berater/beraterfirmenuebersicht/berater' , '2_2', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-statistic.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>statistics</a></li><li><a
+                        href="/premium-service/berater"
+                        title="Premium service"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/premium-service/berater' , '2_3', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/premium-service.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Premium<br>service</a></li></ul></section>
+                                                                                
+        
+    
+                
+                                            
+<section class="tm-link-list-container tm-link-list--full ">
+        <div
+        class="tm-link-list-element"
+        role="navigation"
+        aria-label=""
+    >
+                    
+                        
+                                            <ul
+    class="tm-link-list-unordered   recommendation__links"
+>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/neuestetransfers"
+                    title="Latest transfers"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/neuestetransfers' , '3_1','linkList');"
+                >
+                    Latest transfers
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/rumour-mill/detail/forum/154"
+                    title="Rumour Mill"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/rumour-mill/detail/forum/154' , '3_2','linkList');"
+                >
+                    Rumour Mill
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/aktuell/newsarchiv"
+                    title="All news"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/aktuell/newsarchiv' , '3_3','linkList');"
+                >
+                    All news
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/whatsMyValue"
+                    title="What's my value?"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/whatsMyValue' , '3_4','linkList');"
+                >
+                    What's my value?
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/spieler-statistik/wertvollstespieler/marktwertetop"
+                    title="Most valuable players in the world"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/spieler-statistik/wertvollstespieler/marktwertetop' , '3_5','linkList');"
+                >
+                    Most valuable players in the world
+                </a>
+                    </li>
+    </ul>
+                                            <ul
+    class="tm-link-list-unordered   recommendation__links"
+>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/spieler-statistik/wertvollstemannschaften/marktwertetop"
+                    title="Most valuable clubs in the world"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/spieler-statistik/wertvollstemannschaften/marktwertetop' , '3_6','linkList');"
+                >
+                    Most valuable clubs in the world
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/marktwertanalyse/detail/forum/357"
+                    title="Market value analysis"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/marktwertanalyse/detail/forum/357' , '3_7','linkList');"
+                >
+                    Market value analysis
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/vertragslosespieler"
+                    title="Free agents"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/vertragslosespieler' , '3_8','linkList');"
+                >
+                    Free agents
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/statistik/endendevertraege"
+                    title="Contracts ending"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/statistik/endendevertraege' , '3_9','linkList');"
+                >
+                    Contracts ending
+                </a>
+                    </li>
+            <li
+            class="tm-link-list-item"
+        >
+                            <a
+                    class="tm-link__arrow  "
+                    href="/betting/"
+                    title="Betting"
+                    target="_self"
+                    onclick="tmEvent('recommendations_recommendation', '/betting/' , '3_10','linkList');"
+                >
+                    Betting
+                </a>
+                    </li>
+    </ul>
+                        </div>
+
+    </section>
+                                                                        
+        
+    
+                
+                                    <section class="tm-button-list__wrapper tm-button-list__wrapper--full  tm-button-list__mobile"><span class="tm-discover__h2">Player agents</span><ul class="tm-button-list"><li><a
+                        href="/agent-support/beraterIndex/berater"
+                        title="Agent support"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/agent-support/beraterIndex/berater' , '4_1', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-support.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>support</a></li><li><a
+                        href="/berater/beraterfirmenuebersicht/berater"
+                        title="Agent statistics"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/berater/beraterfirmenuebersicht/berater' , '4_2', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/agent-statistic.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Agent<br>statistics</a></li><li><a
+                        href="/premium-service/berater"
+                        title="Premium service"
+                        target="_self"
+                        class="tm-button-list__list-item tm-button-list__list-item--big tm-button-list__agent"
+                        onclick="tmEvent('recommendations_recommendation', '/premium-service/berater' , '4_3', 'buttonList');"
+                    ><img
+                            src="https://tmsi.akamaized.net/rebrush/navigation/premium-service.webp"
+                            alt=""
+                            class="tm-button-list__image tm-button-list__image--big tm-button-list__image--country tm-button-list__image--border"
+                            width="54"
+                            height="36"
+                        >Premium<br>service</a></li></ul></section>
+                                                                                
+                    </div>
+        
+    </div>
+                                                </div>
+                </div>
+            </nav>
+
+            <div class="quick-select-wrapper">
+    
+    <tm-quick-select defaultCountry="157" defaultCompetition="ES1" defaultClub="131" defaultPlayer="937958" dropdown-visible="" translations='{"home":"Home","country":"Country","competition":"Competition","club":"Club","player":"Player","attack":"Striker","midfield":"Midfielder","defense":"Defender","goalkeeper":"Goalkeeper"}'>
+    </tm-quick-select>
+</div>
+
+            
+        
+        <script type="text/javascript">//RWGzztV("billboard")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-billboard"  data-ad-placement-note="Advertisement">
+  <div id="d_top_1" style="min-width: 1024px; min-height: 250px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_top_1");
+        let has_d_top_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_top_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_top_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_top_1]);
+                has_d_top_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_top_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+
+
+        
+        <main id="tm-main">
+            
+    <div id="modal-1" class="modal micromodal-slide" aria-hidden="true" tabindex="1">
+        <div class="modal__overlay" tabindex="-1" data-custom-close>
+            <div
+                class="modal__container"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="modal-1-title"
+                data-custom-close
+                >
+                <header class="modal__header">
+                    <button
+                        class="modal__close modal__close--profile-img"
+                        aria-label="Close modal"
+                        data-custom-close
+                        >
+                    </button>
+                </header>
+                <div id="modal-1-content" class="modal__content">
+                                        <img src='https://img.a.transfermarkt.technology/portrait/big/937958-1746563945.jpg?lm=1' alt='Lamine Yamal' title='Lamine Yamal' data-custom-close loading="lazy">
+                </div>
+            </div>
+        </div>
+    </div>
+
+<header class="data-header" itemscope itemtype="https://schema.org/Person">
+                    <div class="data-header__headline-container">
+            <h1 class="data-header__headline-wrapper">
+                                    <span class="data-header__shirt-number">
+                        #10                    </span>
+                                <strong>Lamine Yamal</strong>            </h1>
+                            <tm-watchlist player-id="937958"></tm-watchlist>
+                                </div>
+                    <div class="data-header__badge-container">
+                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="Top goal scorer" class="data-header__success-data">
+                                                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://tmssl.akamaized.net//images/titel/header/5.png?lm=1465908312" title="Top goal scorer" alt="Top goal scorer" class="data-header__success-image lazy lazy" />                                                <span class="data-header__success-number">2</span>
+                    </a>
+                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="TM-Player of the season" class="data-header__success-data">
+                                                    <img src="data:image/gif;base64,R0lGODlhAQABAIAAAMLCwgAAACH5BAAAAAAALAAAAAABAAEAAAICRAEAOw==" data-src="https://tmssl.akamaized.net//images/titel/header/256.png?lm=1623075349" title="TM-Player of the season" alt="TM-Player of the season" class="data-header__success-image lazy lazy" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="European champion" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/102.png?lm=1520606997" title="European champion" alt="European champion" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="Spanish champion" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/11.png?lm=1520606997" title="Spanish champion" alt="Spanish champion" class="" />                                                <span class="data-header__success-number">2</span>
+                    </a>
+                                    <a href="/lamine-yamal/erfolge/spieler/937958" title="Spanish cup winner" class="data-header__success-data">
+                                                    <img src="https://tmssl.akamaized.net//images/erfolge/header/94.png?lm=1520606999" title="Spanish cup winner" alt="Spanish cup winner" class="" />                                                <span class="data-header__success-number">1</span>
+                    </a>
+                                                    <a href="/lamine-yamal/erfolge/spieler/937958"
+                       title="All titles & victories"
+                       class="data-header__success-more"
+                    >
+                    </a>
+                            </div>
+        
+                    <div class="data-header__box--big">
+                                    <a href="/fc-barcelona/startseite/verein/131" class="data-header__box__club-link">
+                                            <img srcset="
+                            https://tmssl.akamaized.net//images/wappen/normquad/131.png?lm=1406739548 1x,
+                            https://tmssl.akamaized.net//images/wappen/homepageWappen150x150/131.png?lm=1406739548 2x
+                            " alt="FC Barcelona" height="100" width="100" />
+                                        </a>
+                                <div class="data-header__club-info">
+                    <span class="data-header__club" itemprop="affiliation">
+                        <a title="FC Barcelona" href="/fc-barcelona/startseite/verein/131">Barcelona</a>                    </span><br />                    
+                                                                            <span class="data-header__league">
+                                    <a class="data-header__league-link" href="/laliga/startseite/wettbewerb/ES1">
+                                        <img src="https://tmssl.akamaized.net//images/logo/verytiny/es1.png?lm=1725974302" title="LaLiga" alt="LaLiga" class="" />LaLiga                                    </a>
+                                </span>
+                                                                            <span class="data-header__label">League level:
+                                <span class="data-header__content">
+                                    <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />First Tier                                </span>
+                            </span>
+                                                                                                        <span class="data-header__label">Joined: <span class="data-header__content">01/07/2023</span></span>
+                            <span class="data-header__label">Contract expires: <span class="data-header__content">30/06/2031</span></span>
+                                                            </div>
+            </div>
+        
+        <div class="data-header__profile-container">
+                            <div class="modal-trigger" data-custom-open="modal-1" id="fotoauswahlOeffnen" style="cursor:pointer" onclick="tmEvent('spielerprofil','click','profilbild');">
+            
+                                <img src="https://img.a.transfermarkt.technology/portrait/header/937958-1746563945.jpg?lm=1" title="Lamine Yamal" alt="Lamine Yamal" class="data-header__profile-image" height="181" width="139" /><div class="bildquelle"><span title="IMAGO">IMAGO</span></div>
+                                    <span class="modal-trigger-icon">+</span>
+                </div>
+                        </div>
+        <div class="data-header__info-box ">
+            <div class="data-header__details">
+                <ul class="data-header__items">
+                                            <li class="data-header__label">Date of birth/Age:
+                            <span itemprop="birthDate" class="data-header__content">
+                                13/07/2007 (18)                            </span>
+                        </li>
+
+                                                    <li class="data-header__label">Place of birth:
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />                                <span class="data-header__content" itemprop="birthPlace">
+                                    <span class="cp" title="Esplugues de Llobregat">Esplugues de ...</span>                                </span>
+                            </li>
+                        
+                                            <li class="data-header__label">Citizenship:
+                            <span itemprop="nationality" class="data-header__content">
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" />                                Spain                            </span>
+                        </li>
+                                    </ul>
+                <ul class="data-header__items">
+                                            <li class="data-header__label">Height:
+                            <span itemprop="height" class="data-header__content">
+                                1,80 m                            </span>
+                        </li>
+                    
+                    <li class="data-header__label">Position:
+                        <span class="data-header__content">
+                            Right Winger                        </span>
+                    </li>
+                    
+                        <li class="data-header__label">Agent:
+                            <span class="data-header__content data-header__content--vertical-aligned">
+                                
+                                    <a onclick="tmEvent(&quot;spielerprofil&quot;, &quot;click&quot;, &quot;berater-header-premium&quot;)" href="/gestifute/beraterfirma/berater/413">Gestifute</a>                                                                            <img class="data-header__verified-logo" src="https://tmsi.akamaized.net/berater/verified_premium_minified.png" alt="verified" title="verified" height="13" width="13">
+                                                                                                </span>
+                        </li>
+
+                                    </ul>
+                <ul class="data-header__items">
+                                            <li for="" class="data-header__label">
+                                                            Current international:
+                                                        <span class="data-header__content">
+                                <img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen flagge" /><a title="Spain" href="/spanien/startseite/verein/3375">Spain</a>                            </span>
+                        </li>
+                                                    <li class="data-header__label">Caps/Goals:
+                                <a class="data-header__content data-header__content--highlight" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375">23                                </a>/
+                                <a class="data-header__content data-header__content--highlight" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375">6                                </a>
+                            </li>
+                        <li class="data-header__label theme-button">
+    </li>
+                </ul>
+            </div>
+        </div>
+            
+            <div class="data-header__box--small">
+                <a href="/lamine-yamal/marktwertverlauf/spieler/937958" class="data-header__market-value-wrapper"><span class="waehrung">€</span>200.00<span class="waehrung">m</span>                <p class="data-header__last-update">Last update: 12/12/2025</p></a>
+            </div>
+
+            
+    </header>
+<a href="https://www.transfermarkt.com/transfer-focus-what-do-the-traditional-big-six-clubs-need-this-january-/view/news/431862"
+        target="1"
+    class="db mt10"
+        onclick="tmEvent('banner', 'https://www.transfermarkt.com/transfer-focus-what-do-the-traditional-big-six-clubs-need-this-january-/view/news/431862', 'd-day-banner');"
+>
+    <img
+        loading="lazy"
+        src="https://dzjovqk3zamsg.cloudfront.net/big-six-desktop-banner.jpg"
+        width="1034"
+        height="99"
+        alt="deadline-day banner"
+    >
+</a>
+
+<script type="text/javascript">
+    (() => {
+        const cookies = document.cookie
+            .split(';')
+            .map(c => c.trim().split('='))
+            .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
+        const isContentPassUser = cookies?._cpauthhint !== undefined;
+        if (isContentPassUser) {
+            const adNodes = document.querySelectorAll('.ad-placement-note');
+            adNodes.forEach(node => node.remove());
+        }
+    })();
+</script><tm-subnavigation
+    controller="spieler"
+    id="937958"
+    season=""
+    section="spieler"
+    style="display: block; margin: 0 5px;">
+</tm-subnavigation>
+<div class="row">
+            <div class="large-8 columns">
+            
+<tm-player-national-team-career
+    id="937958"
+    translations="{&quot;widgetTitle&quot;:&quot;National team career&quot;,&quot;shirtNumber&quot;:&quot;#&quot;,&quot;nationalteam&quot;:&quot;National team&quot;,&quot;debut&quot;:&quot;Debut&quot;,&quot;matches&quot;:&quot;Matches&quot;,&quot;goals&quot;:&quot;Goals&quot;,&quot;linkTitle&quot;:&quot;Go to national player profile&quot;,&quot;coachAtDebut&quot;:&quot;Coach at debut&quot;,&quot;ageAtDebut&quot;:&quot;Age at debut&quot;}"
+    ></tm-player-national-team-career>
+            <div class="box">
+                <h2 class="content-box-headline">
+                    Stats of Lamine Yamal                </h2>
+                <p class="info-content">
+                    This snapshot overview displays all of the international games recorded for a particular player in the TM database. Under "Filter by national team", you can filter by appearances for senior national team(s) and appearances for U-xx teams. This will also cause the corresponding information to be shown under "Detailed stats". By clicking on the "Detailed" tab, you can view further details (e.g. substitutions on and off, penalty goals, etc.) for your selected category.                </p>
+                <div class="content">
+                    <form class="js-form-params2path" action="/lamine-yamal/nationalmannschaft/spieler/937958/plus/0" method="post">
+                        <div class="row">
+                            <div class="large-12 columns">
+                                <table class="auflistung">
+                                    <tbody>
+                                        <tr>
+                                            <td>Filter by national team:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="verein_id" data-placeholder="Filter by national team" class="chzn-select" tabindex="0">
+                                                                                                                    <option  selected="selected"value="3375">Spain</option>
+                                                                                                                    <option value="12609">Spain U19</option>
+                                                                                                                    <option value="12395">Spain U17</option>
+                                                                                                                    <option value="33775">Spain U16</option>
+                                                                                                                    <option value="70910">Spain U15</option>
+                                                                                                            </select>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <input type="submit" class="small button" value="Show">
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        </form>                </div>
+                
+<div class="tm-tabs">
+    <a class="tm-tab tm-tab__active--parent" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb//wettbewerb_id//start/2023-09-08/ende/2026-01-09/nurEinsatz/0"><div class=" tm-tab__active"><span>Compact</span></div></a><a class="tm-tab" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb//wettbewerb_id//start/2023-09-08/ende/2026-01-09/nurEinsatz/0/plus/1"><div class=""><span>Detailed</span></div></a></div>
+                <div class="responsive-table">
+                    <div id="yw0" class="grid-view">
+<div class="summary"></div>
+<table class="items">
+<thead>
+<tr>
+<th colspan="2" id="yw0_c0"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/wettbewerb">Competition</a></th><th class="hide" id="yw0_c1"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/wettbewerb">wettbewerb</a></th><th class="zentriert" id="yw0_c2"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/einsaetze.desc"><span class="icons_sprite icon-einsaetze-table-header" title="Appearances">&nbsp;</span></a></th><th class="zentriert" id="yw0_c3"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/tore.desc"><span class="icons_sprite icon-tor-table-header" title="Goals">&nbsp;</span></a></th><th class="zentriert" id="yw0_c4"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/vorlagen.desc"><span class="icons_sprite icon-vorlage-table-header" title="Assists">&nbsp;</span></a></th><th class="zentriert" id="yw0_c5"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/gelbe.desc"><span class="icons_sprite icon-gelbekarte-table-header" title="Yellow cards">&nbsp;</span></a></th><th class="zentriert" id="yw0_c6"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/gelbrote.desc"><span class="icons_sprite icon-gelbrotekarte-table-header" title="Second yellow cards">&nbsp;</span></a></th><th class="zentriert" id="yw0_c7"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/rote.desc"><span class="icons_sprite icon-rotekarte-table-header" title="Red cards">&nbsp;</span></a></th><th class="rechts" id="yw0_c8"><a class="sort-link" href="/lamine-yamal/nationalmannschaft/spieler/937958/sort/einsatzzeit.desc"><span class="icons_sprite icon-minuten-table-header" title="Minutes played">&nbsp;</span></a></th></tr>
+</thead>
+<tfoot>
+<tr>
+<td colspan="2" class="rechts">Total : </td><td class="hide">&nbsp;</td><td class="zentriert">23</td><td class="zentriert">6</td><td class="zentriert">12</td><td class="zentriert">3</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="rechts">1.651'</td></tr>
+</tfoot>
+<tbody>
+<tr class="odd">
+<td class="hauptlink no-border-rechts"><img src="https://tmssl.akamaized.net//images/logo/tiny/unla.png?lm=1512858223" title="UEFA Nations League A" alt="UEFA Nations League A" class="" /></td><td class="hauptlink no-border-links"><a title="UEFA Nations League" href="/uefa-nations-league-a/startseite/pokalwettbewerb/UNLA">UEFA Nations League</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/UNL">7</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/UNL/nurEinsatz/2">3</a></td><td class="zentriert">1</td><td class="zentriert">2</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="rechts">606'</td></tr>
+<tr class="even">
+<td class="hauptlink no-border-rechts"><img src="https://tmssl.akamaized.net//images/logo/tiny/euro.png?lm=1750336783" title="UEFA Euro" alt="UEFA Euro" class="" /></td><td class="hauptlink no-border-links"><a title="UEFA Euro" href="/europameisterschaft/startseite/pokalwettbewerb/EURO">UEFA Euro</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/EURO">7</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/EURO/nurEinsatz/2">1</a></td><td class="zentriert">4</td><td class="zentriert">1</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="rechts">508'</td></tr>
+<tr class="odd">
+<td class="hauptlink no-border-rechts"><img src="https://tmssl.akamaized.net//images/logo/tiny/emq.png?lm=1410165817" title="European Qualifiers" alt="European Qualifiers" class="" /></td><td class="hauptlink no-border-links"><a title="European Qualifiers" href="/em-qualifikation/startseite/pokalwettbewerb/EMQ">European Qualifiers</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/EMQ">4</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/EMQ/nurEinsatz/2">2</a></td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="rechts">205'</td></tr>
+<tr class="even">
+<td class="hauptlink no-border-rechts"><img src="https://tmssl.akamaized.net//images/logo/tiny/fs.png?lm=1713854091" title="International Friendlies" alt="International Friendlies" class="" /></td><td class="hauptlink no-border-links"><a title="International Friendlies" href="/freundschaftsspiele/startseite/wettbewerb/FS">International Friendlies</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/FS">3</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/FS/nurEinsatz/2">-</a></td><td class="zentriert">4</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="rechts">180'</td></tr>
+<tr class="odd">
+<td class="hauptlink no-border-rechts"><img src="https://tmssl.akamaized.net//images/logo/tiny/wmq6.png?lm=1734088642" title="World Cup qualification Europe" alt="World Cup qualification Europe" class="" /></td><td class="hauptlink no-border-links"><a title="World Cup qualification" href="/wm-qualifikation-europa/startseite/pokalwettbewerb/WMQ6">World Cup qualification</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/WMQ">2</a></td><td class="zentriert"><a title="Lamine Yamal" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb/WMQ/nurEinsatz/2">-</a></td><td class="zentriert">3</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="zentriert">-</td><td class="rechts">152'</td></tr>
+</tbody>
+</table>
+<div class="keys" style="display:none" title="/lamine-yamal/nationalmannschaft/spieler/937958"><span>UEFA Nations League</span><span>UEFA Euro</span><span>European Qualifiers</span><span>International Friendlies</span><span>World Cup qualification</span></div>
+</div>                </div>
+            </div>
+                            <div class="box">
+                    <h2 class="content-box-headline">
+                        Detailed stats                    </h2>
+                    <p class="info-content">
+                        This overview shows all of a player's call-ups for the national team selected under "Stats". You can use a filter to limit the selection to major competitions (e.g. world cups), individual competitions (e.g. WC 2014) and to specific time periods. Under "Matches", you can also filter by actual number of matches played or by all matches with goals scored. Under the "Detailed" tab, you can view further details such as the venue and club for which the player was playing at the time of the match.                    </p>
+                    <div class="content">
+                        <form action="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/plus/0" method="get">                        <div class="row">
+                            <div class="large-12 columns">
+                                <table class="auflistung">
+                                    <tbody>
+                                        <tr>
+                                            <td>Filter by major competition:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="hauptwettbewerb" data-placeholder="Filter by competition" class="chzn-select" tabindex="0">
+                                                        <option value="">All</option>
+                                                                                                                    <option value="WMQ">World Cup qualification</option>
+                                                                                                                    <option value="EMQ">European Qualifiers</option>
+                                                                                                                    <option value="FS">International Friendlies</option>
+                                                                                                                    <option value="UNL">UEFA Nations League</option>
+                                                                                                                    <option value="EURO">UEFA Euro</option>
+                                                                                                            </select>
+                                                </div>
+                                            </td>
+                                            <td>
+
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Filter by competition:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="wettbewerb_id" data-placeholder="Filter by competition" class="chzn-select" tabindex="0">
+                                                        <option value="">All</option>
+                                                                                                                    <option value="WMQ6">World Cup qualification Europe</option>
+                                                                                                                    <option value="EMQ">European Qualifiers</option>
+                                                                                                                    <option value="FS">International Friendlies</option>
+                                                                                                                    <option value="UNFI">UEFA Nations League Finals</option>
+                                                                                                                    <option value="UNLA">UEFA Nations League A</option>
+                                                                                                                    <option value="EURO">UEFA Euro</option>
+                                                                                                            </select>
+                                                </div>
+                                            </td>
+                                            <td>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Filter by coach:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="trainer_id" data-placeholder="Filter by coach" class="chzn-select" tabindex="0">
+                                                        <option value="">All</option>
+                                                                                                                    <option value="20031">Luis de la Fuente</option>
+                                                                                                            </select>
+                                                </div>
+                                            </td>
+                                            <td>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                Period:                                            </td>
+                                            <td>
+                                                <input class="" style="font-weight:normal !important;" id="start" type="text" value="08/09/2023" name="start" />                                            </td>
+                                            <td class="zentriert hauptlink">-</td>
+                                            <td>
+                                                <input class="" id="ende" type="text" value="09/01/2026" name="ende" />                                            </td>
+                                            <td>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>Matches:</td>
+                                            <td colspan="3">
+                                                <div class="inline-select">
+                                                    <select name="nurEinsatz" data-placeholder="Choose matches" class="chzn-select" tabindex="0">
+                                                        <option  selected="selected" value="0">All games</option>
+                                                        <option  value="1">Only games where the player appeared</option>
+                                                        <option  value="2">Only games with goals scored</option>
+                                                    </select>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <input type="submit" class="small button" value="Show">
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                        </form>                    </div>
+                    
+<div class="tm-tabs">
+    <a class="tm-tab tm-tab__active--parent" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb//wettbewerb_id//start/2023-09-08/ende/2026-01-09/nurEinsatz/0"><div class=" tm-tab__active"><span>Compact</span></div></a><a class="tm-tab" href="/lamine-yamal/nationalmannschaft/spieler/937958/verein_id/3375/hauptwettbewerb//wettbewerb_id//start/2023-09-08/ende/2026-01-09/nurEinsatz/0/plus/1"><div class=""><span>Detailed</span></div></a></div>
+                    <div class="responsive-table">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th class="zentriert">&nbsp;</th>
+                                    <th class="zentriert">Matchday</th>
+                                                                            <th class="zentriert">Date</th>
+
+                                                                                    <th class="zentriert">Venue</th>
+                                            <th class="zentriert" colspan="2">For</th>
+                                            <th colspan="2">Opponent</th>
+                                                                            
+                                                                            <th class="zentriert">Result</th>
+                                    
+                                    <th class="zentriert">Pos.</th>
+                                    <th class="zentriert"><span class="icons_sprite icon-tor-table-header" title="Goals">&nbsp;</span></th>
+                                    <th class="zentriert"><span class="icons_sprite icon-vorlage-table-header" title="Assists">&nbsp;</span></th>
+                                                                                                                <th class="zentriert"><span class="icons_sprite icon-gelbekarte-table-header" title="Yellow cards">&nbsp;</span></th>
+                                        <th class="zentriert"><span class="icons_sprite icon-gelbrotekarte-table-header" title="Second yellow cards">&nbsp;</span></th>
+                                        <th class="zentriert"><span class="icons_sprite icon-rotekarte-table-header" title="Red cards">&nbsp;</span></th>
+                                                                                                            <th class="rechts"><span class="icons_sprite icon-minuten-table-header" title="Minutes played">&nbsp;</span></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                                                                                                            <tr>
+                                                    <td class="zentriert hauptlink no-border-rechts" style="border-top:1px solid #ddd;border-bottom: none !important;background-color: #f2f2f2 !important;">
+                                                        <a name="EMQ" href="/european-qualifiers/startseite/pokalwettbewerb/EMQ/saison_id/2022">
+
+                                                            <img src="https://tmssl.akamaized.net//images/logo/tiny/emq.png?lm=1410165817" title="European Qualifiers" alt="European Qualifiers" class="" />                                                        </a>
+                                                    </td>
+                                                    <td colspan="20" class=" hauptlink no-border-links" style="border-top:1px solid #ddd;background-color: #f2f2f2 !important;">
+                                                        <a name="EMQ" href="/european-qualifiers/startseite/pokalwettbewerb/EMQ/saison_id/2022">
+                                                            European Qualifiers                                                        </a>
+                                                    </td>
+                                                </tr>
+                                                                                        <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group A</td>
+                                                                                                    <td class="zentriert">08/09/23</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/53.png?lm=1520611569" title="Georgia" alt="Georgia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2022">Georgia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="3941392" href="/spielbericht/index/spielbericht/3941392"><span class="greentext">1:7 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert">1</td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">46'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group A</td>
+                                                                                                    <td class="zentriert">12/09/23</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Cyprus" href="/zypern/spielplan/verein/3668/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/188.png?lm=1520611569" title="Cyprus" alt="Cyprus" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Cyprus" href="/zypern/spielplan/verein/3668/saison_id/2022">Cyprus</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="3941389" href="/spielbericht/index/spielbericht/3941389"><span class="greentext">6:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">61'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group A</td>
+                                                                                                    <td class="zentriert">12/10/23</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Scotland" href="/schottland/spielplan/verein/3380/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/190.png?lm=1520611569" title="Scotland" alt="Scotland" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Scotland" href="/schottland/spielplan/verein/3380/saison_id/2022">Scotland</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="3941386" href="/spielbericht/index/spielbericht/3941386"><span class="greentext">2:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="muscular problems" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>muscular problems</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group A</td>
+                                                                                                    <td class="zentriert">15/10/23</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Norway" href="/norwegen/spielplan/verein/3440/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/125.png?lm=1520611569" title="Norway" alt="Norway" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Norway" href="/norwegen/spielplan/verein/3440/saison_id/2022">Norway</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="3941391" href="/spielbericht/index/spielbericht/3941391"><span class="greentext">0:1 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="muscular problems" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>muscular problems</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group A</td>
+                                                                                                    <td class="zentriert">16/11/23</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Cyprus" href="/zypern/spielplan/verein/3668/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/188.png?lm=1520611569" title="Cyprus" alt="Cyprus" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Cyprus" href="/zypern/spielplan/verein/3668/saison_id/2022">Cyprus</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4228039" href="/spielbericht/index/spielbericht/4228039"><span class="greentext">1:3 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert">1</td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">73'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group A</td>
+                                                                                                    <td class="zentriert">19/11/23</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2022"><img src="https://tmssl.akamaized.net//images/flagge/tiny/53.png?lm=1520611569" title="Georgia" alt="Georgia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2022">Georgia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="3941388" href="/spielbericht/index/spielbericht/3941388"><span class="greentext">3:1 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">25'</td>
+                                                                                            </tr>
+                                                                                                                                <tr>
+                                                    <td class="zentriert hauptlink no-border-rechts" style="border-top:1px solid #ddd;border-bottom: none !important;background-color: #f2f2f2 !important;">
+                                                        <a name="FS" href="/international-friendlies/startseite/pokalwettbewerb/FS/saison_id/2023">
+
+                                                            <img src="https://tmssl.akamaized.net//images/logo/tiny/fs.png?lm=1713854091" title="International Friendlies" alt="International Friendlies" class="" />                                                        </a>
+                                                    </td>
+                                                    <td colspan="20" class=" hauptlink no-border-links" style="border-top:1px solid #ddd;background-color: #f2f2f2 !important;">
+                                                        <a name="FS" href="/international-friendlies/startseite/pokalwettbewerb/FS/saison_id/2023">
+                                                            International Friendlies                                                        </a>
+                                                    </td>
+                                                </tr>
+                                                                                        <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    </td>
+                                                                                                    <td class="zentriert">22/03/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Colombia" href="/kolumbien/spielplan/verein/3816/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/83.png?lm=1520611569" title="Colombia" alt="Colombia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Colombia" href="/kolumbien/spielplan/verein/3816/saison_id/2023">Colombia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4317768" href="/spielbericht/index/spielbericht/4317768"><span class="redtext">0:1 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">18'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    </td>
+                                                                                                    <td class="zentriert">26/03/24</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Brazil" href="/brasilien/spielplan/verein/3439/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/26.png?lm=1520611569" title="Brazil" alt="Brazil" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Brazil" href="/brasilien/spielplan/verein/3439/saison_id/2023">Brazil</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4319276" href="/spielbericht/index/spielbericht/4319276"><span class="">3:3 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">2</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">90'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_gelb_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    </td>
+                                                                                                    <td class="zentriert">05/06/24</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Andorra" href="/andorra/spielplan/verein/10533/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/5.png?lm=1520611569" title="Andorra" alt="Andorra" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Andorra" href="/andorra/spielplan/verein/10533/saison_id/2023">Andorra</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4347242" href="/spielbericht/index/spielbericht/4347242"><span class="greentext">5:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert">on the bench</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    </td>
+                                                                                                    <td class="zentriert">08/06/24</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Northern Ireland" href="/nordirland/spielplan/verein/5674/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/192.png?lm=1520611569" title="Northern Ireland" alt="Northern Ireland" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Northern Ireland" href="/nordirland/spielplan/verein/5674/saison_id/2023">N. Ireland</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4347262" href="/spielbericht/index/spielbericht/4347262"><span class="greentext">5:1 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">2</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">72'</td>
+                                                                                            </tr>
+                                                                                                                                <tr>
+                                                    <td class="zentriert hauptlink no-border-rechts" style="border-top:1px solid #ddd;border-bottom: none !important;background-color: #f2f2f2 !important;">
+                                                        <a name="EURO" href="/uefa-euro/startseite/pokalwettbewerb/EURO/saison_id/2023">
+
+                                                            <img src="https://tmssl.akamaized.net//images/logo/tiny/euro.png?lm=1750336783" title="UEFA Euro" alt="UEFA Euro" class="" />                                                        </a>
+                                                    </td>
+                                                    <td colspan="20" class=" hauptlink no-border-links" style="border-top:1px solid #ddd;background-color: #f2f2f2 !important;">
+                                                        <a name="EURO" href="/uefa-euro/startseite/pokalwettbewerb/EURO/saison_id/2023">
+                                                            UEFA Euro                                                        </a>
+                                                    </td>
+                                                </tr>
+                                                                                        <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group B</td>
+                                                                                                    <td class="zentriert">15/06/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Croatia" href="/kroatien/spielplan/verein/3556/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/37.png?lm=1520611569" title="Croatia" alt="Croatia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Croatia" href="/kroatien/spielplan/verein/3556/saison_id/2023">Croatia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4235809" href="/spielbericht/index/spielbericht/4235809"><span class="greentext">3:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">1</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">86'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group B</td>
+                                                                                                    <td class="zentriert">20/06/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Italy" href="/italien/spielplan/verein/3376/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/75.png?lm=1520611569" title="Italy" alt="Italy" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Italy" href="/italien/spielplan/verein/3376/saison_id/2023">Italy</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4235822" href="/spielbericht/index/spielbericht/4235822"><span class="greentext">1:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">71'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group B</td>
+                                                                                                    <td class="zentriert">24/06/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Albania" href="/albanien/spielplan/verein/3561/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/3.png?lm=1520611569" title="Albania" alt="Albania" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Albania" href="/albanien/spielplan/verein/3561/saison_id/2023">Albania</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4235834" href="/spielbericht/index/spielbericht/4235834"><span class="greentext">0:1 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">19'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Round of 16</td>
+                                                                                                    <td class="zentriert">30/06/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/53.png?lm=1520611569" title="Georgia" alt="Georgia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2023">Georgia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4359330" href="/spielbericht/index/spielbericht/4359330"><span class="greentext">4:1 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">1</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">90'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Quarter-Finals</td>
+                                                                                                    <td class="zentriert">05/07/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Germany" href="/deutschland/spielplan/verein/3262/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/40.png?lm=1520612525" title="Germany" alt="Germany" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Germany" href="/deutschland/spielplan/verein/3262/saison_id/2023">Germany</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4359336" href="/spielbericht/index/spielbericht/4359336"><span class="greentext">2:1 <span class="ergebnis_zusatz">AET</span></span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">1</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">63'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Semi-Finals</td>
+                                                                                                    <td class="zentriert">09/07/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="France" href="/frankreich/spielplan/verein/3377/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/50.png?lm=1520611569" title="France" alt="France" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="France" href="/frankreich/spielplan/verein/3377/saison_id/2023">France</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4359340" href="/spielbericht/index/spielbericht/4359340"><span class="greentext">2:1 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert">1</td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert">90'</td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">90'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Final</td>
+                                                                                                    <td class="zentriert">14/07/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="England" href="/england/spielplan/verein/3299/saison_id/2023"><img src="https://tmssl.akamaized.net//images/flagge/tiny/189.png?lm=1520611569" title="England" alt="England" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="England" href="/england/spielplan/verein/3299/saison_id/2023">England</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4359342" href="/spielbericht/index/spielbericht/4359342"><span class="greentext">2:1 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">1</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">89'</td>
+                                                                                            </tr>
+                                                                                                                                <tr>
+                                                    <td class="zentriert hauptlink no-border-rechts" style="border-top:1px solid #ddd;border-bottom: none !important;background-color: #f2f2f2 !important;">
+                                                        <a name="UNLA" href="/uefa-nations-league-a/startseite/pokalwettbewerb/UNLA/saison_id/2024">
+
+                                                            <img src="https://tmssl.akamaized.net//images/logo/tiny/unla.png?lm=1512858223" title="UEFA Nations League A" alt="UEFA Nations League A" class="" />                                                        </a>
+                                                    </td>
+                                                    <td colspan="20" class=" hauptlink no-border-links" style="border-top:1px solid #ddd;background-color: #f2f2f2 !important;">
+                                                        <a name="UNLA" href="/uefa-nations-league-a/startseite/pokalwettbewerb/UNLA/saison_id/2024">
+                                                            UEFA Nations League A                                                        </a>
+                                                    </td>
+                                                </tr>
+                                                                                        <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group 4</td>
+                                                                                                    <td class="zentriert">05/09/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Serbia" href="/serbien/spielplan/verein/3438/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/215.png?lm=1520611569" title="Serbia" alt="Serbia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Serbia" href="/serbien/spielplan/verein/3438/saison_id/2024">Serbia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4284267" href="/spielbericht/index/spielbericht/4284267"><span class="">0:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert">41'</td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">90'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group 4</td>
+                                                                                                    <td class="zentriert">08/09/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Switzerland" href="/schweiz/spielplan/verein/3384/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/148.png?lm=1520611569" title="Switzerland" alt="Switzerland" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Switzerland" href="/schweiz/spielplan/verein/3384/saison_id/2024">Switzerland</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4284264" href="/spielbericht/index/spielbericht/4284264"><span class="greentext">1:4 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">1</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">45'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group 4</td>
+                                                                                                    <td class="zentriert">12/10/24</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Denmark" href="/danemark/spielplan/verein/3436/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/39.png?lm=1520611569" title="Denmark" alt="Denmark" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Denmark" href="/danemark/spielplan/verein/3436/saison_id/2024">Denmark</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4284258" href="/spielbericht/index/spielbericht/4284258"><span class="greentext">1:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">90'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group 4</td>
+                                                                                                    <td class="zentriert">15/10/24</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Serbia" href="/serbien/spielplan/verein/3438/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/215.png?lm=1520611569" title="Serbia" alt="Serbia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Serbia" href="/serbien/spielplan/verein/3438/saison_id/2024">Serbia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4284260" href="/spielbericht/index/spielbericht/4284260"><span class="greentext">3:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="strain" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>strain</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group 4</td>
+                                                                                                    <td class="zentriert">15/11/24</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Denmark" href="/danemark/spielplan/verein/3436/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/39.png?lm=1520611569" title="Denmark" alt="Denmark" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Denmark" href="/danemark/spielplan/verein/3436/saison_id/2024">Denmark</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4284261" href="/spielbericht/index/spielbericht/4284261"><span class="greentext">1:2 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="Ankle injury" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>Ankle injury</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group 4</td>
+                                                                                                    <td class="zentriert">18/11/24</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Switzerland" href="/schweiz/spielplan/verein/3384/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/148.png?lm=1520611569" title="Switzerland" alt="Switzerland" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Switzerland" href="/schweiz/spielplan/verein/3384/saison_id/2024">Switzerland</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4284259" href="/spielbericht/index/spielbericht/4284259"><span class="greentext">3:2 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="Ankle injury" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>Ankle injury</td>
+                                                                                            </tr>
+                                                                                                                                <tr>
+                                                    <td class="zentriert hauptlink no-border-rechts" style="border-top:1px solid #ddd;border-bottom: none !important;background-color: #f2f2f2 !important;">
+                                                        <a name="UNFI" href="/uefa-nations-league-finals/startseite/pokalwettbewerb/UNFI/saison_id/2024">
+
+                                                            <img src="https://tmssl.akamaized.net//images/logo/tiny/unfi.png?lm=1543845323" title="UEFA Nations League Finals" alt="UEFA Nations League Finals" class="" />                                                        </a>
+                                                    </td>
+                                                    <td colspan="20" class=" hauptlink no-border-links" style="border-top:1px solid #ddd;background-color: #f2f2f2 !important;">
+                                                        <a name="UNFI" href="/uefa-nations-league-finals/startseite/pokalwettbewerb/UNFI/saison_id/2024">
+                                                            UEFA Nations League Finals                                                        </a>
+                                                    </td>
+                                                </tr>
+                                                                                        <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Quarter-Finals 1st leg</td>
+                                                                                                    <td class="zentriert">20/03/25</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Netherlands" href="/niederlande/spielplan/verein/3379/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/122.png?lm=1520611569" title="Netherlands" alt="Netherlands" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Netherlands" href="/niederlande/spielplan/verein/3379/saison_id/2024">Netherlands</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4498075" href="/spielbericht/index/spielbericht/4498075"><span class="">2:2 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">66'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Quarter-Finals 2nd leg</td>
+                                                                                                    <td class="zentriert">23/03/25</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Netherlands" href="/niederlande/spielplan/verein/3379/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/122.png?lm=1520611569" title="Netherlands" alt="Netherlands" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Netherlands" href="/niederlande/spielplan/verein/3379/saison_id/2024">Netherlands</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4498079" href="/spielbericht/index/spielbericht/4498079"><span class="greentext">8:7 <span class="ergebnis_zusatz">on pens</span></span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert">1</td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">120'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Semi-Finals</td>
+                                                                                                    <td class="zentriert">05/06/25</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="France" href="/frankreich/spielplan/verein/3377/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/50.png?lm=1520611569" title="France" alt="France" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="France" href="/frankreich/spielplan/verein/3377/saison_id/2024">France</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4498088" href="/spielbericht/index/spielbericht/4498088"><span class="greentext">5:4 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert">2</td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert">33'</td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">90'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Final</td>
+                                                                                                    <td class="zentriert">08/06/25</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Portugal" href="/portugal/spielplan/verein/3300/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/136.png?lm=1520611569" title="Portugal" alt="Portugal" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Portugal" href="/portugal/spielplan/verein/3300/saison_id/2024">Portugal</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4498090" href="/spielbericht/index/spielbericht/4498090"><span class="redtext">7:5 <span class="ergebnis_zusatz">on pens</span></span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert"></td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">105'</td>
+                                                                                            </tr>
+                                                                                                                                <tr>
+                                                    <td class="zentriert hauptlink no-border-rechts" style="border-top:1px solid #ddd;border-bottom: none !important;background-color: #f2f2f2 !important;">
+                                                        <a name="WMQ6" href="/world-cup-qualification-europe/startseite/pokalwettbewerb/WMQ6/saison_id/2024">
+
+                                                            <img src="https://tmssl.akamaized.net//images/logo/tiny/wmq6.png?lm=1734088642" title="World Cup qualification Europe" alt="World Cup qualification Europe" class="" />                                                        </a>
+                                                    </td>
+                                                    <td colspan="20" class=" hauptlink no-border-links" style="border-top:1px solid #ddd;background-color: #f2f2f2 !important;">
+                                                        <a name="WMQ6" href="/world-cup-qualification-europe/startseite/pokalwettbewerb/WMQ6/saison_id/2024">
+                                                            World Cup qualification Europe                                                        </a>
+                                                    </td>
+                                                </tr>
+                                                                                        <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group E</td>
+                                                                                                    <td class="zentriert">04/09/25</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Bulgaria" href="/bulgarien/spielplan/verein/3394/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/28.png?lm=1520611569" title="Bulgaria" alt="Bulgaria" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Bulgaria" href="/bulgarien/spielplan/verein/3394/saison_id/2024">Bulgaria</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4510739" href="/spielbericht/index/spielbericht/4510739"><span class="greentext">0:3 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">1</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">79'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group E</td>
+                                                                                                    <td class="zentriert">07/09/25</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Turkiye" href="/turkei/spielplan/verein/3381/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/174.png?lm=1520611569" title="Turkiye" alt="Turkiye" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Turkiye" href="/turkei/spielplan/verein/3381/saison_id/2024">Turkiye</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4510665" href="/spielbericht/index/spielbericht/4510665"><span class="greentext">0:6 </span></a>                                                    </td>
+                                                
+                                                                                                    <td class="zentriert"><a href="" title="Right Winger">RW</a></td>
+                                                    <td class="zentriert"></td>
+                                                    <td class="zentriert">2</td>
+                                                    
+                                                                                                            <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                        <td class="zentriert"></td>
+                                                    
+
+
+                                                                                                        <td class="rechts">73'</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group E</td>
+                                                                                                    <td class="zentriert">11/10/25</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/53.png?lm=1520611569" title="Georgia" alt="Georgia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2024">Georgia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4510741" href="/spielbericht/index/spielbericht/4510741"><span class="greentext">2:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="Groin problems" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>Groin problems</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group E</td>
+                                                                                                    <td class="zentriert">14/10/25</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Bulgaria" href="/bulgarien/spielplan/verein/3394/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/28.png?lm=1520611569" title="Bulgaria" alt="Bulgaria" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Bulgaria" href="/bulgarien/spielplan/verein/3394/saison_id/2024">Bulgaria</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4510666" href="/spielbericht/index/spielbericht/4510666"><span class="greentext">4:0 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="Groin problems" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>Groin problems</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group E</td>
+                                                                                                    <td class="zentriert">15/11/25</td>
+                                                                                                            <td class="zentriert hauptlink">A</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/53.png?lm=1520611569" title="Georgia" alt="Georgia" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Georgia" href="/georgien/spielplan/verein/3669/saison_id/2024">Georgia</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4510736" href="/spielbericht/index/spielbericht/4510736"><span class="greentext">0:4 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="Pubalgia" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>Pubalgia</td>
+                                                                                            </tr>
+                                                                                                                            <tr class="bg_rot_20">
+                                                <td style="border-top: none !important;border-bottom: none !important;background-color: #f2f2f2 !important;">
+
+                                                </td>
+                                                <td class="zentriert">
+                                                    Group E</td>
+                                                                                                    <td class="zentriert">18/11/25</td>
+                                                                                                            <td class="zentriert hauptlink">H</td>
+
+                                                                                                                                                                                    <td class="zentriert" colspan="2"><a title="Spain" href="/spanien/spielplan/verein/3375/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/157.png?lm=1520611569" title="Spain" alt="Spain" class="flaggenrahmen" /></a></td>
+                                                                                                                        <td class="zentriert no-border-rechts"><a title="Turkiye" href="/turkei/spielplan/verein/3381/saison_id/2024"><img src="https://tmssl.akamaized.net//images/flagge/tiny/174.png?lm=1520611569" title="Turkiye" alt="Turkiye" class="flaggenrahmen" /></a></td>
+                                                            <td class="no-border-links hauptlink"><a title="Turkiye" href="/turkei/spielplan/verein/3381/saison_id/2024">Turkiye</a></td>
+                                                                                                                                                            
+                                                                                                    <td class="zentriert">
+                                                        <a title="Match report" class="ergebnis-link" id="4510740" href="/spielbericht/index/spielbericht/4510740"><span class="">2:2 </span></a>                                                    </td>
+                                                
+                                                                                                    <td colspan="8" class="zentriert"><span title="Pubalgia" class="verletzt-table mittig-vom-text icons_sprite">&nbsp;</span>Pubalgia</td>
+                                                                                            </tr>
+                                                                </tbody>
+                            <foot>
+                                <tr>
+                                    <td colspan="20">Squad: 24, Starting eleven: 19, Substituted in: 4, On the bench: 1, Suspended: 0, Injured: 9, </td>
+                                </tr>
+                            </foot>
+                        </table>
+                    </div>
+                </div>
+
+                </div>
+                    <div class="large-4 columns">
+                <script type="text/javascript">//RWGzztV("rectangle1")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-rectangle1"  data-ad-placement-note="Advertisement">
+  <div id="d_side_1" style="min-width: 336px; min-height: 280px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_side_1");
+        let has_d_side_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_side_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_side_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_side_1]);
+                has_d_side_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "0px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_side_1"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+                                    <div class="box hide-for-small">
+                        <div class="content zentriert">
+                            <img src="https://img.a.transfermarkt.technology/portrait/big/937958-1718794101.jpg?lm=1" title="Lamine Yamal" alt="Lamine Yamal" class="bilderrahmen" /><div class="bildquelle"><span title="IMAGO">IMAGO</span></div>                        </div>
+                    </div>
+                                <script type="text/javascript">//RWGzztV("rectangle2")</script>
+<div class="ad-placement-note ad-placement-background werbung werbung-rectangle2"  data-ad-placement-note="Advertisement">
+  <div id="d_side_2" style="min-width: 336px; min-height: 280px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_side_2");
+        let has_d_side_2_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_side_2_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_side_2", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_side_2]);
+                has_d_side_2_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_side_2"));
+      });
+    </script>
+  </div>
+</div>
+
+<span class="RWGzztV_end"></span>
+            </div>
+            </div>
+
+<script async src="/js/custom/tm-track-links.min.js" type="module"></script>
+
+<div class="ad-placement-note ad-placement-background werbung werbung-fullsize_contentad"  data-ad-placement-note="Advertisement">
+  <div id="d_bottom_1" style="min-width: 1024px; min-height: 250px;">
+    <script>
+      googletag.cmd.push(() => {
+        googletag.display("d_bottom_1");
+        let has_d_bottom_1_refreshed = false;
+        var observer = new IntersectionObserver((entries) => {
+          entries.forEach(entry => {
+            if(entry.isIntersecting === true && !has_d_bottom_1_refreshed) {
+              googletag.cmd.push(() => {
+                console.info("%c [TM-ADs] IntersectionObserver renders d_bottom_1", "background: #282828; color: #bada55")
+                googletag.pubads().refresh([ad_d_bottom_1]);
+                has_d_bottom_1_refreshed = true;
+              });
+            }
+          });
+        }, { threshold: [0], rootMargin: "500px 0px 0px 0px" });
+      observer.observe(document.querySelector("#d_bottom_1"));
+      });
+    </script>
+  </div>
+</div>
+
+
+        </main>
+        <footer class="tm-footer">
+               <section class="tm-footer__section-quick-links">
+        <strong class="tm-footer__headline tm-footer__headline--large">
+            Quick Links        </strong>
+        <div class="tm-footer__link-wrapper">
+            <a href="/spieler-statistik/wertvollstespieler/marktwertetop"
+               onclick="tmEvent('footer', 'quick_links', '/spieler-statistik/wertvollstespieler')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Most valuable players in the world            </a>
+            <a href="/statistik/neuestetransfers"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/neuestetransfers')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest transfers            </a>
+            <a href="/geruechte/aktuellegeruechte/statistik"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/aktuellegeruechte')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest rumours            </a>
+            <a href="/spieler-statistik/marktwertaenderungen/marktwertetop"
+                onclick="tmEvent('footer', 'quick_links', '/spieler-statistik/marktwertaenderungen/marktwertetop')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Latest market value updates            </a>
+            <a href="/statistik/weltrangliste"
+                onclick="tmEvent('footer', 'quick_links', '/statistik/weltrangliste')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                FIFA World ranking            </a>
+                        <a href="/betting/"
+                onclick="tmEvent('footer', 'quick_links', '/betting/')"
+               class="tm-footer__link tm-footer__link--arrow"
+            >
+                Betting            </a>
+                    </div>
+    </section>
+                <section class="tm-footer__section-involved">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                Be Involved            </strong>
+            <div class="tm-footer__link-wrapper">
+                <a href="/intern/paten"
+                    onclick="tmEvent('footer', 'be_involved', 'mods_data_scouts')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Mods & Data Scouts                </a>
+                <a href="/profil/bewerbung"
+                    onclick="tmEvent('footer', 'be_involved', 'apply_mod_datascout')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Apply as Mod or Datascout                </a>
+                <a href="/intern/elfGebote"
+                    onclick="tmEvent('footer', 'be_involved', '11_commandments')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    11 commandments                </a>
+                <a href="/intern/fehlermelden"
+                    onclick="tmEvent('footer', 'be_involved', 'found_mistake')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    Found a mistake?                </a>
+            </div>
+        </section>
+        <section class="tm-footer__section-career">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                Career            </strong>
+            <div class="tm-footer__link-wrapper">
+                                <a href="/intern/tmteam"
+                   class="tm-footer__link tm-footer__link--arrow"
+                   onclick="tmEvent('footer', 'career', 'contact')"
+                >
+                    Contact                </a>
+            </div>
+        </section>
+        <section class="tm-footer__section-about">
+            <strong class="tm-footer__headline tm-footer__headline--large">
+                About Us            </strong>
+            <div class="tm-footer__link-wrapper">
+                <a href="/intern/tmteam"
+                   onclick="tmEvent('footer', 'about_us', 'tm_team')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    TM-Team                </a>
+                <a href="/intern/faq"
+                   onclick="tmEvent('footer', 'about_us', 'faq')"
+                   class="tm-footer__link tm-footer__link--arrow"
+                >
+                    FAQ                </a>
+            </div>
+        </section>
+            <section class="tm-footer__section-social">
+        <strong class="tm-footer__headline
+            ">
+            Social media        </strong>
+        <div class="tm-footer__social-wrapper">
+                        <a href="https://www.instagram.com/transfermarkt_official/"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'instagram')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/instaRebrush.svg"
+                         alt="instagram"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.facebook.com/transfermarkt.global"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'facebook')">
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/fbRebrush.svg"
+                         alt="facebook"
+                         width="25"
+                         height="25"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.whatsapp.com/channel/0029Va6Kevx47XeF0gE99J35"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'whatsapp')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/whatsappRebrush.svg"
+                         alt="whatsapp"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://twitter.com/TMuk_news"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'x')">
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/twitter_rebrush.svg"
+                         alt="x"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.threads.net/@transfermarkt_official"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'threads')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/threadsRebrush.svg"
+                         alt="threads"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.tiktok.com/@transfermarkt"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'tiktok')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/tiktokRebrush.svg"
+                         alt="tiktok"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://www.youtube.com/@TransfermarktEnglish"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'youtube')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/RebrushYoutube.svg"
+                         alt="youtube"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                <a href="https://t.me/transfermarkt_off"
+                   target="_blank"
+                   class="tm-footer__link-social"
+                   onclick="tmEvent('footer', 'social_media', 'telegram')"
+                >
+                    <img src="https://tmsi.akamaized.net/icons/socialMedia/telegramRebrush.svg"
+                         alt="telegram"
+                         width="28"
+                         height="28"
+                         class="tm-footer__icon-social"
+                    >
+                </a>
+                        </div>
+    </section>
+                </footer>
+                <div id="menue_overlay"></div>
+    </div>
+    <section class="tm-footer__mobile tm-footer__transfermarkt-info">
+        <section class="tm-footer__section-desktop-width">
+                            <section class="tm-footer__section-company-links">
+                    <span class="tm-footer__headline tm-footer__headline--medium">
+                        Transfermarkt Company Projects                    </span>
+                    <div class="tm-footer__project-wrapper">
+                        <a href="/wahretabelle"
+                           onclick="tmEvent('footer', 'projects', 'wahretabelle')"
+                           class="tm-footer__link"
+                        >
+                            Wahretabelle                        </a>
+                        <a href="https://www.soccerdonna.de/"
+                           onclick="tmEvent('footer', 'projects', 'soccerdonna')"
+                           class="tm-footer__link"
+                        >
+                            Soccerdonna.de                        </a>
+                        <a href="https://scoutastic.com/de/"
+                           onclick="tmEvent('footer', 'projects', 'scoutastic')"
+                           class="tm-footer__link"
+                        >
+                            Scoutastic.com                        </a>
+                    </div>
+                </section>
+                        <section class="tm-footer__section-company-infos">
+                <span class="tm-footer__headline tm-footer__headline--medium">&copy; Transfermarkt <span id="currentYear">2026</span></span>
+                <div class="tm-footer__company-wrapper">
+                    <a
+                    href="/intern/impressum"
+                    class="tm-footer__link tm-footer__link--blue"
+                    onclick="tmEvent('footer', 'officials', 'impressum')"
+                    >
+                        Legal notice                    </a>
+                    <a
+                        href="/intern/web/datenschutz"
+                        class="tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'data_protection')"
+                        >
+                        Data protection                    </a>
+                    <a
+                        href="javascript:void(0)"
+                        class="cmp-link tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'privacy')"
+                    >
+                        Privacy                    </a>
+                    <a
+                        href="javascript:void(0)"
+                        class="revoke-tracking tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'tracking_revocation')"
+                    >
+                        Revoke Tracking                    </a>
+                    <a
+                        href="/intern/anb"
+                        class="tm-footer__link tm-footer__link--blue"
+                        onclick="tmEvent('footer', 'officials', 'general_conduct_of_use')"
+                        >
+                        Site policy                    </a>
+                                    </div>
+            </section>
+        </section>
+    </section>
+    <script type="text/javascript">
+	if(typeof(adet) == "boolean" && adet == false){
+		img_src="/static/singlepictures/jk99hhfsdh209nbnkjldgh90sghfsdlk";
+	} else {
+		img_src="/static/singlepictures/jku90whjlkjbwbta1g4b8h89fh8sgh8d";
+	}
+	var elem = document.createElement("img");
+	document.body.appendChild(elem);
+	elem.src = img_src;
+</script>
+
+            <script>
+            document.addEventListener('DOMContentLoaded', function() {
+                var cnt = document.querySelectorAll('div.large-4.columns').length;
+                if (cnt == 1) {
+                    var sidebarDiv = document.querySelector('div.large-4.columns');
+                    if (sidebarDiv !== null) {
+                        var sidebar = document.getElementById('werbung_recommender_sidebar_wrapper');
+                        sidebarDiv.appendChild(sidebar);
+                        sidebar.style.display = 'block';
+                    }
+                }
+            });
+        </script>
+        <div id="werbung_recommender_sidebar_wrapper" style="display: none;">
+                    </div>
+    <tm-consent type="adition" no-checkbox embed="PHNjcmlwdCBzcmM9Imh0dHBzOi8vY3JlYXRpdmUtY2RuLm9kZHNzZXJ2ZS5jb20vbG9hZGVyLmpzP3B1Ymxpc2hlcj10bSIgYXN5bmM9ImFzeW5jIj48L3NjcmlwdD4="></tm-consent><tm-consent type='adrenalead' no-checkbox embed='PHNjcmlwdCB0eXBlPSd0ZXh0L2phdmFzY3JpcHQnPgogICAgICAgICAgICB3aW5kb3cuX25BZHpxPXdpbmRvdy5fbkFkenF8fFtdOyhmdW5jdGlvbigpewogICAgICAgICAgICB3aW5kb3cuX25BZHpxLnB1c2goWydzZXRJZHMnLCdkNWE0YzFhNzU4Njc4YTUxJ10pOwogICAgICAgICAgICB2YXIgZT0naHR0cHM6Ly9ub3RpZnB1c2guY29tL3NjcmlwdHMvJzsKICAgICAgICAgICAgdmFyIHQ9ZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7CiAgICAgICAgICAgIHQudHlwZT0ndGV4dC9qYXZhc2NyaXB0JzsKICAgICAgICAgICAgdC5kZWZlcj10cnVlOwogICAgICAgICAgICB0LmFzeW5jPXRydWU7CiAgICAgICAgICAgIHQuc3JjPWUrJ25hZHotc2RrLmpzJzsKICAgICAgICAgICAgdmFyIHM9ZG9jdW1lbnQuZ2V0RWxlbWVudHNCeVRhZ05hbWUoJ3NjcmlwdCcpWzBdOwogICAgICAgICAgICBzLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKHQscyl9KSgpOwogICAgICAgIDwvc2NyaXB0Pg=='></tm-consent>    
+        <tm-modal id="tm-modal-revoke-tracking" additionalClose="Close">
+        <div class="tm-modal__headline">Revoke Tracking</div>
+        <p class="tm-modal__text">Sie haben erfolgreich Ihre Einwilligung in die Nutzung von Transfermarkt mit Tracking und Cookies widerrufen. Sie können sich jetzt zwischen dem Contentpass-Abo und der Nutzung mit personalisierter Werbung, Cookies und Tracking entscheiden.</p>
+    </tm-modal>
+
+<tm-consent type="pubmatic" no-checkbox embed="PHNjcmlwdCB0eXBlPSd0ZXh0L2phdmFzY3JpcHQnPgogICAgICAgICAgICAgICAgICAgICAgICB2YXIgUFdUPXt9OwogICAgICAgICAgICAgICAgICAgICAgICB2YXIgZ29vZ2xldGFnID0gZ29vZ2xldGFnIHx8IHt9OwogICAgICAgICAgICAgICAgICAgICAgICBnb29nbGV0YWcuY21kID0gZ29vZ2xldGFnLmNtZCB8fCBbXTsKICAgICAgICAgICAgICAgICAgICAgICAgdmFyIGdwdFJhbiA9IGZhbHNlOwogICAgICAgICAgICAgICAgICAgICAgICBQV1QuanNMb2FkZWQgPSAoKSA9PiB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBsb2FkR1BUKCk7CiAgICAgICAgICAgICAgICAgICAgICAgIH07CiAgICAgICAgICAgICAgICAgICAgICAgIHZhciBsb2FkR1BUID0gZnVuY3Rpb24oKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBpZiAoIWdwdFJhbikgewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdwdFJhbiA9IHRydWU7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIGdhZHMgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdzY3JpcHQnKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgdXNlU1NMID0gJ2h0dHBzOicgPT0gZG9jdW1lbnQubG9jYXRpb24ucHJvdG9jb2w7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ2Fkcy5zcmMgPSAodXNlU1NMID8gJ2h0dHBzOicgOiAnaHR0cDonKSArICcvL3NlY3VyZXB1YmFkcy5nLmRvdWJsZWNsaWNrLm5ldC90YWcvanMvZ3B0LmpzJzsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbm9kZSA9IGRvY3VtZW50LmdldEVsZW1lbnRzQnlUYWdOYW1lKCdzY3JpcHQnKVswXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBub2RlLnBhcmVudE5vZGUuaW5zZXJ0QmVmb3JlKGdhZHMsIG5vZGUpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgICAgICB9OwogICAgICAgICAgICAgICAgICAgICAgICAvLyBGYWlsc2FmZSB0byBjYWxsIGdwdAogICAgICAgICAgICAgICAgICAgICAgICBzZXRUaW1lb3V0KGxvYWRHUFQsIDUwMCk7CgogICAgICAgICAgICAgICAgICAgICAgICAoZnVuY3Rpb24oKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgcHVybCA9IHdpbmRvdy5sb2NhdGlvbi5ocmVmOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIHVybCA9ICcvL2Fkcy5wdWJtYXRpYy5jb20vQWRTZXJ2ZXIvanMvcHd0LzE2MzIyOS8xMDEwMyc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgcHJvZmlsZVZlcnNpb25JZCA9ICcnOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgaWYocHVybC5pbmRleE9mKCdwd3R2PScpPjApewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHZhciByZWdleHAgPSAvcHd0dj0oLio/KSgmfCQpL2c7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbWF0Y2hlcyA9IHJlZ2V4cC5leGVjKHB1cmwpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgaWYobWF0Y2hlcy5sZW5ndGggPj0gMiAmJiBtYXRjaGVzWzFdLmxlbmd0aCA+IDApewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHByb2ZpbGVWZXJzaW9uSWQgPSAnLycrbWF0Y2hlc1sxXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgICAgICAgICAgdmFyIHd0YWRzID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnc2NyaXB0Jyk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy5hc3luYyA9IHRydWU7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy50eXBlID0gJ3RleHQvamF2YXNjcmlwdCc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB3dGFkcy5zcmMgPSB1cmwrcHJvZmlsZVZlcnNpb25JZCsnL3B3dC5qcyc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB2YXIgbm9kZSA9IGRvY3VtZW50LmdldEVsZW1lbnRzQnlUYWdOYW1lKCdzY3JpcHQnKVswXTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIG5vZGUucGFyZW50Tm9kZS5pbnNlcnRCZWZvcmUod3RhZHMsIG5vZGUpOwogICAgICAgICAgICAgICAgICAgICAgICB9KSgpOwogICAgICAgICAgICAgICAgICAgIDwvc2NyaXB0PgogICAgICAgICAgICAgICAgICAgIA=="></tm-consent><tm-consent type="googleadvertising" no-checkbox embed="PHNjcmlwdCAgc3JjPSJodHRwczovL3NlY3VyZXB1YmFkcy5nLmRvdWJsZWNsaWNrLm5ldC90YWcvanMvZ3B0LmpzIiBhc3luYz0iYXN5bmMiPjwvc2NyaXB0Pg=="></tm-consent>
+<tm-consent type="googleadvertising" no-checkbox embed="PHNjcmlwdCAgc3JjPSJodHRwczovL2MuYW1hem9uLWFkc3lzdGVtLmNvbS9hYXgyL2Fwc3RhZy5qcyIgYXN5bmM9ImFzeW5jIj48L3NjcmlwdD4="></tm-consent>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/watchlist/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/subnavigation/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/player-national-team-career/bundle.js"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/assets/aa69c6e9c51f1e811847082c63633956/gridview/jquery.yiigridview.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/assets/b7c5571cf8957553f95f6d9069eaed67/jui/js/jquery-ui.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/custom/vendors.min.js?lm=1767953048"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/domain-switcher/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/quick-select-bar/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/userbox/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/live-match-count/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/domain-note/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/consent/bundle.js"></script>
+<script type="text/javascript" src="https://tmsi.akamaized.net/js/svelte-components/modal/bundle.js"></script>
+<script type="text/javascript" src="https://tmssl.akamaized.net/js/custom/tm-skyscraper.min.js?lm=1767953048"></script>
+<script type="text/javascript">
+/*<![CDATA[*/
+	var loginUrl='/profil/login';
+	var onlyDE = '';
+	var onlyMobile = '';
+	var onlyTablet = '';
+	var getUserID = '';
+
+jQuery(function($) {
+jQuery('#yw0').yiiGridView({'ajaxUpdate':['yw0'],'ajaxVar':'ajax','pagerClass':'pager','loadingClass':'grid\x2Dview\x2Dloading','filterClass':'filters','tableClass':'items','selectableRows':1,'enableHistory':false,'updateSelector':'\x7Bpage\x7D,\x20\x7Bsort\x7D','filterSelector':'\x7Bfilter\x7D','afterAjaxUpdate':function() {window.LazyLoadInstance.update(); tmTrackingAndAds(); trackLinks(); document.dispatchEvent(new CustomEvent("tmInitTooltip"));}});
+jQuery('#start').datepicker({'dateFormat':'dd.mm.yy','yearRange':'\x2D200\x3A\x2B1','changeYear':'true','changeMonth':'true'});
+jQuery('#ende').datepicker({'dateFormat':'dd.mm.yy','yearRange':'\x2D200\x3A\x2B1','changeYear':'true','changeMonth':'true'});
+});
+/*]]>*/
+</script>
+</body>
+
+</html>

--- a/tfmkt/spiders/competitions.py
+++ b/tfmkt/spiders/competitions.py
@@ -93,6 +93,16 @@ class CompetitionsSpider(BaseSpider):
                     'href': '/primavera-1/startseite/wettbewerb/IJ1',
                     'code': 'IJ1',
                     'type': 'youth_league'
+                },
+                {
+                    'href': '/primavera-2-a/startseite/wettbewerb/IJ2A',
+                    'code': 'IJ2A',
+                    'type': 'youth_league'
+                },
+                {
+                    'href': '/primavera-2-b/startseite/wettbewerb/IJ2B',
+                    'code': 'IJ2B',
+                    'type': 'youth_league'
                 }
             ]
             for comp in manual_competitions:

--- a/tfmkt/spiders/games_by_url.py
+++ b/tfmkt/spiders/games_by_url.py
@@ -22,6 +22,58 @@ class GamesByUrlSpider(GamesSpider):
 
   name = 'games_by_url'
 
+  def __init__(self, *args, **kwargs):
+    """Initialize spider and preserve parent fields from input.
+
+    BaseSpider.__init__() deletes nested parent fields to prevent infinite
+    nesting (lines 44-46 in common_comp_club.py). However, for games the
+    parent field contains essential competition information that must be
+    preserved and passed through to the final output.
+
+    This override saves parent data before calling super().__init__() and
+    restores it afterward.
+    """
+    import json
+    import gzip
+    import sys
+
+    # Extract parents parameter to determine input source
+    parents_file = kwargs.get('parents')
+    saved_parent_data = {}
+
+    # Pre-read input to save parent data before BaseSpider deletes it
+    if parents_file:
+      # Determine if file is gzipped
+      extension = parents_file.split(".")[-1]
+      is_gzipped = (extension == "gz")
+
+      # Open and read the file
+      open_fn = gzip.open if is_gzipped else open
+      mode = 'rt' if is_gzipped else 'r'
+
+      with open_fn(parents_file, mode) as f:
+        for line in f:
+          entry = json.loads(line)
+          # Save the nested parent field (competition info) keyed by href
+          if entry.get('href') and entry.get('parent'):
+            saved_parent_data[entry['href']] = entry['parent']
+
+    elif not sys.stdin.isatty():
+      # Handle piped input from stdin
+      for line in sys.stdin:
+        entry = json.loads(line)
+        if entry.get('href') and entry.get('parent'):
+          saved_parent_data[entry['href']] = entry['parent']
+
+    # Call parent init (this will load data and delete parent fields)
+    super().__init__(*args, **kwargs)
+
+    # Restore parent data to entrypoints
+    for entry in self.entrypoints:
+      href = entry.get('href')
+      if href in saved_parent_data:
+        entry['parent'] = saved_parent_data[href]
+
   def parse(self, response, parent):
     """Parse game page directly from URL.
 

--- a/tfmkt/spiders/games_urls.py
+++ b/tfmkt/spiders/games_urls.py
@@ -18,6 +18,7 @@ class GamesUrlsSpider(BaseSpider):
     {
       "type": "game",
       "href": "/spielbericht/index/spielbericht/3098550",
+      "seasoned_href": "https://www.transfermarkt.co.uk/spielbericht/index/spielbericht/3098550",
       "game_id": 3098550,
       "date_iso": "2024-09-26",
       "date_display": "Sep 26, 2024",
@@ -68,7 +69,7 @@ class GamesUrlsSpider(BaseSpider):
     @url https://www.transfermarkt.co.uk/premier-league/gesamtspielplan/wettbewerb/GB1/saison_id/2020
     @returns items 330 390
     @cb_kwargs {"base": {"href": "some_href", "type": "league", "parent": {}}}
-    @scrapes type href parent game_id date_iso date_display kickoff_time home_club away_club result
+    @scrapes type href seasoned_href parent game_id date_iso date_display kickoff_time home_club away_club result
     """
     # Find all table rows that contain game links
     game_rows = response.xpath('//table//tbody/tr[.//a[@class="ergebnis-link"]]')
@@ -134,10 +135,14 @@ class GamesUrlsSpider(BaseSpider):
       if result in ['-:-', '', 'vs']:
         result = None
 
+      # Build full absolute URL for the game
+      seasoned_href = f"{self.base_url}{href}"
+
       # Yield game item with all metadata
       yield {
         'type': 'game',
         'href': href,
+        'seasoned_href': seasoned_href,
         'game_id': game_id,
         'date_iso': date_iso,
         'date_display': date_display,

--- a/tfmkt/spiders/players.py
+++ b/tfmkt/spiders/players.py
@@ -1,3 +1,4 @@
+import scrapy
 from tfmkt.spiders.common import BaseSpider
 from scrapy.shell import Response
 from scrapy.shell import inspect_response # required for debugging
@@ -44,6 +45,162 @@ class PlayersSpider(BaseSpider):
         return death_date_text_alt.split(" (")[0]
       return death_date_text_alt
     return None
+
+  def _parse_stat_value(self, value):
+    """Parse stat value, converting '-' to 0 and handling None."""
+    if value is None:
+      return 0
+    value = self.safe_strip(value)
+    if value == '-' or value == '':
+      return 0
+    try:
+      return int(value)
+    except ValueError:
+      return 0
+
+  def _parse_minutes(self, value):
+    """Parse minutes played, removing apostrophe and thousand separators."""
+    if value is None:
+      return 0
+    value = self.safe_strip(value)
+    if value == '-' or value == '':
+      return 0
+    value = value.replace("'", "").replace(".", "").replace(",", "")
+    try:
+      return int(value)
+    except ValueError:
+      return 0
+
+  def _extract_game_id(self, href):
+    """Extract game ID from match report href."""
+    if href is None:
+      return None
+    try:
+      return int(href.split('/')[-1])
+    except (ValueError, IndexError):
+      return None
+
+  def _get_result_type(self, span_class):
+    """Determine result type from span class."""
+    if span_class is None:
+      return 'draw'
+    if 'greentext' in span_class:
+      return 'win'
+    elif 'redtext' in span_class:
+      return 'loss'
+    return 'draw'
+
+  def _extract_national_team_stats(self, response):
+    """Extract stats from a national career page for one national team.
+
+    Returns dict with totals, competitions, and matches.
+    """
+    # Check if compact stats table exists
+    compact_table = response.xpath("//table[@class='items']")
+
+    if not compact_table:
+      return {'totals': None, 'competitions': [], 'matches': []}
+
+    # Extract totals from tfoot
+    # Note: first td has colspan=2 but is still one element, so indices are shifted
+    totals_row = compact_table.xpath(".//tfoot/tr")
+    totals = {
+      'appearances': self._parse_stat_value(totals_row.xpath("./td[3]/text()").get()),
+      'goals': self._parse_stat_value(totals_row.xpath("./td[4]/text()").get()),
+      'assists': self._parse_stat_value(totals_row.xpath("./td[5]/text()").get()),
+      'yellow_cards': self._parse_stat_value(totals_row.xpath("./td[6]/text()").get()),
+      'second_yellow_cards': self._parse_stat_value(totals_row.xpath("./td[7]/text()").get()),
+      'red_cards': self._parse_stat_value(totals_row.xpath("./td[8]/text()").get()),
+      'minutes_played': self._parse_minutes(totals_row.xpath("./td[9]/text()").get())
+    }
+
+    # Extract competition summaries from tbody
+    competitions = []
+    for row in compact_table.xpath(".//tbody/tr"):
+      comp = {
+        'name': row.xpath("./td[2]/a/@title").get(),
+        'href': row.xpath("./td[2]/a/@href").get(),
+        'icon_url': row.xpath("./td[1]/img/@src").get(),
+        'appearances': self._parse_stat_value(row.xpath("./td[3]//text()").get()),
+        'goals': self._parse_stat_value(row.xpath("./td[4]//text()").get()),
+        'assists': self._parse_stat_value(row.xpath("./td[5]/text()").get()),
+        'yellow_cards': self._parse_stat_value(row.xpath("./td[6]/text()").get()),
+        'second_yellow_cards': self._parse_stat_value(row.xpath("./td[7]/text()").get()),
+        'red_cards': self._parse_stat_value(row.xpath("./td[8]/text()").get()),
+        'minutes_played': self._parse_minutes(row.xpath("./td[9]/text()").get())
+      }
+      competitions.append(comp)
+
+    # Extract detailed match-by-match stats
+    matches = []
+    detailed_table = response.xpath("(//div[@class='responsive-table'])[2]//table/tbody")
+
+    current_competition = None
+    current_competition_href = None
+
+    for row in detailed_table.xpath("./tr"):
+      # Check if this is a competition header row (has colspan="20")
+      header_link = row.xpath("./td[@colspan='20']/a")
+      if header_link:
+        current_competition = self.safe_strip(header_link.xpath("./text()").get())
+        current_competition_href = header_link.xpath("./@href").get()
+        continue
+
+      # Skip rows without a result link
+      result_link = row.xpath(".//a[@class='ergebnis-link']")
+      if not result_link:
+        continue
+
+      # Check if this is an unavailable/injury row
+      row_class = row.xpath("./@class").get() or ''
+      is_unavailable = 'bg_rot_20' in row_class
+
+      # Detailed table structure:
+      # td[1]=empty, td[2]=matchday, td[3]=date, td[4]=venue, td[5]=team(colspan=2),
+      # td[6]=opponent flag, td[7]=opponent name, td[8]=result, td[9]=position,
+      # td[10]=goals, td[11]=assists, td[12]=yellow, td[13]=2nd yellow, td[14]=red, td[15]=minutes
+      match = {
+        'competition': current_competition,
+        'competition_href': current_competition_href,
+        'matchday': self.safe_strip(row.xpath("./td[2]/text()").get()),
+        'date': self.safe_strip(row.xpath("./td[3]/text()").get()),
+        'venue': self.safe_strip(row.xpath("./td[4]/text()").get()),
+        'team': row.xpath("./td[5]//a/@title").get(),
+        'team_href': row.xpath("./td[5]//a/@href").get(),
+        'opponent': row.xpath("./td[7]//a/@title").get(),
+        'opponent_href': row.xpath("./td[7]//a/@href").get(),
+        'game_href': result_link.xpath("./@href").get(),
+        'game_id': self._extract_game_id(result_link.xpath("./@href").get()),
+        'result': self.safe_strip(result_link.xpath(".//span/text()").get()),
+        'result_type': self._get_result_type(result_link.xpath(".//span/@class").get())
+      }
+
+      if is_unavailable:
+        match['unavailable'] = self.safe_strip(
+          row.xpath(".//td[@colspan]//span[@class='verletzt-table']/following-sibling::text()").get()
+        ) or self.safe_strip(row.xpath(".//td[@colspan]//text()[normalize-space() and not(parent::span)]").get())
+        match['position'] = None
+        match['position_full'] = None
+        match['goals'] = 0
+        match['assists'] = 0
+        match['yellow_cards'] = 0
+        match['second_yellow_cards'] = 0
+        match['red_cards'] = 0
+        match['minutes_played'] = 0
+      else:
+        match['unavailable'] = None
+        match['position'] = row.xpath("./td[9]/a/text()").get()
+        match['position_full'] = row.xpath("./td[9]/a/@title").get()
+        match['goals'] = self._parse_stat_value(row.xpath("./td[10]/text()").get())
+        match['assists'] = self._parse_stat_value(row.xpath("./td[11]/text()").get())
+        match['yellow_cards'] = self._parse_stat_value(row.xpath("./td[12]/text()").get())
+        match['second_yellow_cards'] = self._parse_stat_value(row.xpath("./td[13]/text()").get())
+        match['red_cards'] = self._parse_stat_value(row.xpath("./td[14]/text()").get())
+        match['minutes_played'] = self._parse_minutes(row.xpath("./td[15]/text()").get())
+
+      matches.append(match)
+
+    return {'totals': totals, 'competitions': competitions, 'matches': matches}
 
   def parse(self, response, parent):
       """Parse clubs's page to collect all player's urls.
@@ -273,10 +430,207 @@ class PlayersSpider(BaseSpider):
         if cleaned and cleaned != "-":
             attributes['contract_there_expires'] = cleaned
 
+    # Build national career URL and follow
+    national_career_href = base['href'].replace('/profil/', '/nationalmannschaft/')
+
+    yield response.follow(
+        national_career_href,
+        self.parse_national_career,
+        cb_kwargs={'base': base, 'attributes': attributes},
+        errback=self.errback_national_career
+    )
+
+  def parse_national_career(self, response, base, attributes):
+    """Parse national career page, extract stats for default team, and queue additional teams.
+
+    This method:
+    1. Extracts list of all national teams from dropdown
+    2. Extracts stats for the default (selected) national team
+    3. Queues requests for remaining national teams
+    """
+
+    # Extract all national teams from dropdown
+    # Format: <option value="3375">Spain</option>
+    national_teams = []
+    dropdown_options = response.xpath("//select[@name='verein_id']/option")
+
+    for option in dropdown_options:
+      team_id = option.xpath("./@value").get()
+      team_name = self.safe_strip(option.xpath("./text()").get())
+      is_selected = option.xpath("./@selected").get() is not None
+
+      if team_id and team_name:
+        national_teams.append({
+          'id': team_id,
+          'name': team_name,
+          'is_selected': is_selected
+        })
+
+    # If no national teams found, yield with empty national_career
+    if not national_teams:
+      yield {
+        **base,
+        **attributes,
+        'national_career': []
+      }
+      return
+
+    # Extract stats for the currently displayed (selected) national team
+    selected_team = next((t for t in national_teams if t['is_selected']), national_teams[0])
+    stats = self._extract_national_team_stats(response)
+
+    first_career_entry = {
+      'national_team': {
+        'id': selected_team['id'],
+        'name': selected_team['name'],
+        'href': f"/{selected_team['name'].lower().replace(' ', '-')}/startseite/verein/{selected_team['id']}"
+      },
+      **stats
+    }
+
+    # Get remaining teams that need to be fetched
+    remaining_teams = [t for t in national_teams if not t['is_selected']]
+
+    if not remaining_teams:
+      # Only one national team, yield final result
+      yield {
+        **base,
+        **attributes,
+        'national_career': [first_career_entry]
+      }
+      return
+
+    # Queue requests for remaining teams
+    # Pass accumulated data through cb_kwargs
+    next_team = remaining_teams[0]
+    remaining_after_next = remaining_teams[1:]
+
+    # Build URL for next team
+    base_url = base['href'].replace('/profil/', '/nationalmannschaft/')
+    next_url = f"{base_url}/verein_id/{next_team['id']}"
+
+    yield response.follow(
+      next_url,
+      self.parse_national_team_stats,
+      cb_kwargs={
+        'base': base,
+        'attributes': attributes,
+        'national_career': [first_career_entry],
+        'current_team': next_team,
+        'remaining_teams': remaining_after_next
+      },
+      errback=self.errback_national_team_stats
+    )
+
+  def parse_national_team_stats(self, response, base, attributes, national_career, current_team, remaining_teams):
+    """Parse stats for a specific national team and continue to next or yield final result."""
+
+    # Extract stats for this national team
+    stats = self._extract_national_team_stats(response)
+
+    career_entry = {
+      'national_team': {
+        'id': current_team['id'],
+        'name': current_team['name'],
+        'href': f"/{current_team['name'].lower().replace(' ', '-')}/startseite/verein/{current_team['id']}"
+      },
+      **stats
+    }
+
+    # Add to accumulated national_career list
+    national_career.append(career_entry)
+
+    if not remaining_teams:
+      # All teams processed, yield final result
+      yield {
+        **base,
+        **attributes,
+        'national_career': national_career
+      }
+      return
+
+    # Continue to next team
+    next_team = remaining_teams[0]
+    remaining_after_next = remaining_teams[1:]
+
+    base_url = base['href'].replace('/profil/', '/nationalmannschaft/')
+    next_url = f"{base_url}/verein_id/{next_team['id']}"
+
+    yield response.follow(
+      next_url,
+      self.parse_national_team_stats,
+      cb_kwargs={
+        'base': base,
+        'attributes': attributes,
+        'national_career': national_career,
+        'current_team': next_team,
+        'remaining_teams': remaining_after_next
+      },
+      errback=self.errback_national_team_stats
+    )
+
+  def errback_national_career(self, failure):
+    """Handle failures fetching initial national career page."""
+    request = failure.request
+    base = request.cb_kwargs.get('base', {})
+    attributes = request.cb_kwargs.get('attributes', {})
+
+    self.logger.warning(
+      "Failed to fetch national career for %s: %s",
+      base.get('href'),
+      failure.value
+    )
+
     yield {
       **base,
-      **attributes
+      **attributes,
+      'national_career': []
     }
+
+  def errback_national_team_stats(self, failure):
+    """Handle failures fetching a specific national team's stats."""
+    request = failure.request
+    base = request.cb_kwargs.get('base', {})
+    attributes = request.cb_kwargs.get('attributes', {})
+    national_career = request.cb_kwargs.get('national_career', [])
+    current_team = request.cb_kwargs.get('current_team', {})
+    remaining_teams = request.cb_kwargs.get('remaining_teams', [])
+
+    self.logger.warning(
+      "Failed to fetch national team stats for %s (team %s): %s",
+      base.get('href'),
+      current_team.get('name'),
+      failure.value
+    )
+
+    # Continue with remaining teams or yield what we have
+    if not remaining_teams:
+      yield {
+        **base,
+        **attributes,
+        'national_career': national_career
+      }
+      return
+
+    # Try next team
+    next_team = remaining_teams[0]
+    remaining_after_next = remaining_teams[1:]
+
+    base_url = base['href'].replace('/profil/', '/nationalmannschaft/')
+    next_url = f"{base_url}/verein_id/{next_team['id']}"
+
+    yield scrapy.Request(
+      self.base_url + next_url,
+      callback=self.parse_national_team_stats,
+      cb_kwargs={
+        'base': base,
+        'attributes': attributes,
+        'national_career': national_career,
+        'current_team': next_team,
+        'remaining_teams': remaining_after_next
+      },
+      errback=self.errback_national_team_stats
+    )
 
   def parse_market_history(self, response: Response):
     """

--- a/tfmkt/spiders/players_from_file.py
+++ b/tfmkt/spiders/players_from_file.py
@@ -1,3 +1,4 @@
+import scrapy
 from tfmkt.spiders.common import BaseSpider
 from scrapy.shell import Response
 from scrapy.shell import inspect_response # required for debugging
@@ -43,6 +44,162 @@ class PlayersFromFileSpider(BaseSpider):
         return death_date_text_alt.split(" (")[0]
       return death_date_text_alt
     return None
+
+  def _parse_stat_value(self, value):
+    """Parse stat value, converting '-' to 0 and handling None."""
+    if value is None:
+      return 0
+    value = self.safe_strip(value)
+    if value == '-' or value == '':
+      return 0
+    try:
+      return int(value)
+    except ValueError:
+      return 0
+
+  def _parse_minutes(self, value):
+    """Parse minutes played, removing apostrophe and thousand separators."""
+    if value is None:
+      return 0
+    value = self.safe_strip(value)
+    if value == '-' or value == '':
+      return 0
+    value = value.replace("'", "").replace(".", "").replace(",", "")
+    try:
+      return int(value)
+    except ValueError:
+      return 0
+
+  def _extract_game_id(self, href):
+    """Extract game ID from match report href."""
+    if href is None:
+      return None
+    try:
+      return int(href.split('/')[-1])
+    except (ValueError, IndexError):
+      return None
+
+  def _get_result_type(self, span_class):
+    """Determine result type from span class."""
+    if span_class is None:
+      return 'draw'
+    if 'greentext' in span_class:
+      return 'win'
+    elif 'redtext' in span_class:
+      return 'loss'
+    return 'draw'
+
+  def _extract_national_team_stats(self, response):
+    """Extract stats from a national career page for one national team.
+
+    Returns dict with totals, competitions, and matches.
+    """
+    # Check if compact stats table exists
+    compact_table = response.xpath("//table[@class='items']")
+
+    if not compact_table:
+      return {'totals': None, 'competitions': [], 'matches': []}
+
+    # Extract totals from tfoot
+    # Note: first td has colspan=2 but is still one element, so indices are shifted
+    totals_row = compact_table.xpath(".//tfoot/tr")
+    totals = {
+      'appearances': self._parse_stat_value(totals_row.xpath("./td[3]/text()").get()),
+      'goals': self._parse_stat_value(totals_row.xpath("./td[4]/text()").get()),
+      'assists': self._parse_stat_value(totals_row.xpath("./td[5]/text()").get()),
+      'yellow_cards': self._parse_stat_value(totals_row.xpath("./td[6]/text()").get()),
+      'second_yellow_cards': self._parse_stat_value(totals_row.xpath("./td[7]/text()").get()),
+      'red_cards': self._parse_stat_value(totals_row.xpath("./td[8]/text()").get()),
+      'minutes_played': self._parse_minutes(totals_row.xpath("./td[9]/text()").get())
+    }
+
+    # Extract competition summaries from tbody
+    competitions = []
+    for row in compact_table.xpath(".//tbody/tr"):
+      comp = {
+        'name': row.xpath("./td[2]/a/@title").get(),
+        'href': row.xpath("./td[2]/a/@href").get(),
+        'icon_url': row.xpath("./td[1]/img/@src").get(),
+        'appearances': self._parse_stat_value(row.xpath("./td[3]//text()").get()),
+        'goals': self._parse_stat_value(row.xpath("./td[4]//text()").get()),
+        'assists': self._parse_stat_value(row.xpath("./td[5]/text()").get()),
+        'yellow_cards': self._parse_stat_value(row.xpath("./td[6]/text()").get()),
+        'second_yellow_cards': self._parse_stat_value(row.xpath("./td[7]/text()").get()),
+        'red_cards': self._parse_stat_value(row.xpath("./td[8]/text()").get()),
+        'minutes_played': self._parse_minutes(row.xpath("./td[9]/text()").get())
+      }
+      competitions.append(comp)
+
+    # Extract detailed match-by-match stats
+    matches = []
+    detailed_table = response.xpath("(//div[@class='responsive-table'])[2]//table/tbody")
+
+    current_competition = None
+    current_competition_href = None
+
+    for row in detailed_table.xpath("./tr"):
+      # Check if this is a competition header row (has colspan="20")
+      header_link = row.xpath("./td[@colspan='20']/a")
+      if header_link:
+        current_competition = self.safe_strip(header_link.xpath("./text()").get())
+        current_competition_href = header_link.xpath("./@href").get()
+        continue
+
+      # Skip rows without a result link
+      result_link = row.xpath(".//a[@class='ergebnis-link']")
+      if not result_link:
+        continue
+
+      # Check if this is an unavailable/injury row
+      row_class = row.xpath("./@class").get() or ''
+      is_unavailable = 'bg_rot_20' in row_class
+
+      # Detailed table structure:
+      # td[1]=empty, td[2]=matchday, td[3]=date, td[4]=venue, td[5]=team(colspan=2),
+      # td[6]=opponent flag, td[7]=opponent name, td[8]=result, td[9]=position,
+      # td[10]=goals, td[11]=assists, td[12]=yellow, td[13]=2nd yellow, td[14]=red, td[15]=minutes
+      match = {
+        'competition': current_competition,
+        'competition_href': current_competition_href,
+        'matchday': self.safe_strip(row.xpath("./td[2]/text()").get()),
+        'date': self.safe_strip(row.xpath("./td[3]/text()").get()),
+        'venue': self.safe_strip(row.xpath("./td[4]/text()").get()),
+        'team': row.xpath("./td[5]//a/@title").get(),
+        'team_href': row.xpath("./td[5]//a/@href").get(),
+        'opponent': row.xpath("./td[7]//a/@title").get(),
+        'opponent_href': row.xpath("./td[7]//a/@href").get(),
+        'game_href': result_link.xpath("./@href").get(),
+        'game_id': self._extract_game_id(result_link.xpath("./@href").get()),
+        'result': self.safe_strip(result_link.xpath(".//span/text()").get()),
+        'result_type': self._get_result_type(result_link.xpath(".//span/@class").get())
+      }
+
+      if is_unavailable:
+        match['unavailable'] = self.safe_strip(
+          row.xpath(".//td[@colspan]//span[@class='verletzt-table']/following-sibling::text()").get()
+        ) or self.safe_strip(row.xpath(".//td[@colspan]//text()[normalize-space() and not(parent::span)]").get())
+        match['position'] = None
+        match['position_full'] = None
+        match['goals'] = 0
+        match['assists'] = 0
+        match['yellow_cards'] = 0
+        match['second_yellow_cards'] = 0
+        match['red_cards'] = 0
+        match['minutes_played'] = 0
+      else:
+        match['unavailable'] = None
+        match['position'] = row.xpath("./td[9]/a/text()").get()
+        match['position_full'] = row.xpath("./td[9]/a/@title").get()
+        match['goals'] = self._parse_stat_value(row.xpath("./td[10]/text()").get())
+        match['assists'] = self._parse_stat_value(row.xpath("./td[11]/text()").get())
+        match['yellow_cards'] = self._parse_stat_value(row.xpath("./td[12]/text()").get())
+        match['second_yellow_cards'] = self._parse_stat_value(row.xpath("./td[13]/text()").get())
+        match['red_cards'] = self._parse_stat_value(row.xpath("./td[14]/text()").get())
+        match['minutes_played'] = self._parse_minutes(row.xpath("./td[15]/text()").get())
+
+      matches.append(match)
+
+    return {'totals': totals, 'competitions': competitions, 'matches': matches}
 
   def parse(self, response, parent):
     """Extract player details from the main page.
@@ -219,4 +376,204 @@ class PlayersFromFileSpider(BaseSpider):
     if contract_there_expires:
         attributes['contract_there_expires'] = contract_there_expires.strip()
 
-    yield attributes
+    # Build national career URL and follow
+    national_career_href = base['href'].replace('/profil/', '/nationalmannschaft/')
+
+    yield response.follow(
+        national_career_href,
+        self.parse_national_career,
+        cb_kwargs={'base': base, 'attributes': attributes},
+        errback=self.errback_national_career
+    )
+
+  def parse_national_career(self, response, base, attributes):
+    """Parse national career page, extract stats for default team, and queue additional teams.
+
+    This method:
+    1. Extracts list of all national teams from dropdown
+    2. Extracts stats for the default (selected) national team
+    3. Queues requests for remaining national teams
+    """
+
+    # Extract all national teams from dropdown
+    # Format: <option value="3375">Spain</option>
+    national_teams = []
+    dropdown_options = response.xpath("//select[@name='verein_id']/option")
+
+    for option in dropdown_options:
+      team_id = option.xpath("./@value").get()
+      team_name = self.safe_strip(option.xpath("./text()").get())
+      is_selected = option.xpath("./@selected").get() is not None
+
+      if team_id and team_name:
+        national_teams.append({
+          'id': team_id,
+          'name': team_name,
+          'is_selected': is_selected
+        })
+
+    # If no national teams found, yield with empty national_career
+    if not national_teams:
+      yield {
+        **base,
+        **attributes,
+        'national_career': []
+      }
+      return
+
+    # Extract stats for the currently displayed (selected) national team
+    selected_team = next((t for t in national_teams if t['is_selected']), national_teams[0])
+    stats = self._extract_national_team_stats(response)
+
+    first_career_entry = {
+      'national_team': {
+        'id': selected_team['id'],
+        'name': selected_team['name'],
+        'href': f"/{selected_team['name'].lower().replace(' ', '-')}/startseite/verein/{selected_team['id']}"
+      },
+      **stats
+    }
+
+    # Get remaining teams that need to be fetched
+    remaining_teams = [t for t in national_teams if not t['is_selected']]
+
+    if not remaining_teams:
+      # Only one national team, yield final result
+      yield {
+        **base,
+        **attributes,
+        'national_career': [first_career_entry]
+      }
+      return
+
+    # Queue requests for remaining teams
+    # Pass accumulated data through cb_kwargs
+    next_team = remaining_teams[0]
+    remaining_after_next = remaining_teams[1:]
+
+    # Build URL for next team
+    base_url = base['href'].replace('/profil/', '/nationalmannschaft/')
+    next_url = f"{base_url}/verein_id/{next_team['id']}"
+
+    yield response.follow(
+      next_url,
+      self.parse_national_team_stats,
+      cb_kwargs={
+        'base': base,
+        'attributes': attributes,
+        'national_career': [first_career_entry],
+        'current_team': next_team,
+        'remaining_teams': remaining_after_next
+      },
+      errback=self.errback_national_team_stats
+    )
+
+  def parse_national_team_stats(self, response, base, attributes, national_career, current_team, remaining_teams):
+    """Parse stats for a specific national team and continue to next or yield final result."""
+
+    # Extract stats for this national team
+    stats = self._extract_national_team_stats(response)
+
+    career_entry = {
+      'national_team': {
+        'id': current_team['id'],
+        'name': current_team['name'],
+        'href': f"/{current_team['name'].lower().replace(' ', '-')}/startseite/verein/{current_team['id']}"
+      },
+      **stats
+    }
+
+    # Add to accumulated national_career list
+    national_career.append(career_entry)
+
+    if not remaining_teams:
+      # All teams processed, yield final result
+      yield {
+        **base,
+        **attributes,
+        'national_career': national_career
+      }
+      return
+
+    # Continue to next team
+    next_team = remaining_teams[0]
+    remaining_after_next = remaining_teams[1:]
+
+    base_url = base['href'].replace('/profil/', '/nationalmannschaft/')
+    next_url = f"{base_url}/verein_id/{next_team['id']}"
+
+    yield response.follow(
+      next_url,
+      self.parse_national_team_stats,
+      cb_kwargs={
+        'base': base,
+        'attributes': attributes,
+        'national_career': national_career,
+        'current_team': next_team,
+        'remaining_teams': remaining_after_next
+      },
+      errback=self.errback_national_team_stats
+    )
+
+  def errback_national_career(self, failure):
+    """Handle failures fetching initial national career page."""
+    request = failure.request
+    base = request.cb_kwargs.get('base', {})
+    attributes = request.cb_kwargs.get('attributes', {})
+
+    self.logger.warning(
+      "Failed to fetch national career for %s: %s",
+      base.get('href'),
+      failure.value
+    )
+
+    yield {
+      **base,
+      **attributes,
+      'national_career': []
+    }
+
+  def errback_national_team_stats(self, failure):
+    """Handle failures fetching a specific national team's stats."""
+    request = failure.request
+    base = request.cb_kwargs.get('base', {})
+    attributes = request.cb_kwargs.get('attributes', {})
+    national_career = request.cb_kwargs.get('national_career', [])
+    current_team = request.cb_kwargs.get('current_team', {})
+    remaining_teams = request.cb_kwargs.get('remaining_teams', [])
+
+    self.logger.warning(
+      "Failed to fetch national team stats for %s (team %s): %s",
+      base.get('href'),
+      current_team.get('name'),
+      failure.value
+    )
+
+    # Continue with remaining teams or yield what we have
+    if not remaining_teams:
+      yield {
+        **base,
+        **attributes,
+        'national_career': national_career
+      }
+      return
+
+    # Try next team
+    next_team = remaining_teams[0]
+    remaining_after_next = remaining_teams[1:]
+
+    base_url = base['href'].replace('/profil/', '/nationalmannschaft/')
+    next_url = f"{base_url}/verein_id/{next_team['id']}"
+
+    yield scrapy.Request(
+      self.base_url + next_url,
+      callback=self.parse_national_team_stats,
+      cb_kwargs={
+        'base': base,
+        'attributes': attributes,
+        'national_career': national_career,
+        'current_team': next_team,
+        'remaining_teams': remaining_after_next
+      },
+      errback=self.errback_national_team_stats
+    )


### PR DESCRIPTION
## Summary

This PR implements parity between `players.py` and `players_from_file.py` by porting the national team career scraping feature from PR #1, adds spider synchronization documentation, and includes two new Italian youth leagues.

### Changes

#### 1. National Team Career Scraping (players_from_file.py)
- ✅ Added `import scrapy` statement
- ✅ Added 4 helper methods for stat parsing:
  - `_parse_stat_value()` - Parse appearances, goals, assists, cards
  - `_parse_minutes()` - Parse minutes with thousand separators
  - `_extract_game_id()` - Extract game IDs from URLs
  - `_get_result_type()` - Determine win/loss/draw from CSS classes
- ✅ Added `_extract_national_team_stats()` - Core extraction method (110 lines)
- ✅ Modified `parse()` method to follow to national career page
- ✅ Added `parse_national_career()` - Handles dropdown extraction and first team
- ✅ Added `parse_national_team_stats()` - Recursive method for additional teams
- ✅ Added error handlers for graceful degradation:
  - `errback_national_career()` - Yields empty array on failure
  - `errback_national_team_stats()` - Continues with remaining teams

#### 2. Spider Synchronization Documentation (CLAUDE.md)
- ✅ Added new "Spider Synchronization" section after "Project Structure"
- ✅ Documented architectural differences between the two spiders
- ✅ Established synchronization rule: both spiders should produce identical output
- ✅ Listed current synchronized features:
  - Player profile data extraction
  - National team career scraping
  - Market value parsing
  - Status detection (active/retired/deceased)
  - Error handling with graceful degradation

#### 3. Italian Youth Leagues (competitions.py)
- ✅ Added Primavera 2-A (IJ2A) to Italy manual competitions
- ✅ Added Primavera 2-B (IJ2B) to Italy manual competitions

### Implementation Details

**All code copied verbatim from `players.py` lines 49-633:**
- Helper methods are identical
- Extraction logic is identical
- Error handling is identical
- Both spiders now produce the same output structure for the same player URL

**Spider Synchronization Rule:**
Moving forward, any data extraction changes to `players.py::parse_details()` should be mirrored in `players_from_file.py::parse()` to maintain parity.

### Output Structure

Both spiders now yield items with:
```python
{
  # ... existing player fields ...
  "national_career": [
    {
      "national_team": {"id": "3375", "name": "Spain", "href": "/..."},
      "totals": {"appearances": 23, "goals": 6, ...},
      "competitions": [...],
      "matches": [...]
    },
    // ... additional national teams (U21, U19, etc.)
  ]
}
```

### Related Issues
- Builds upon PR #1 which added national career scraping to `players.py`
- Implements spider parity as discussed in project requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)