### PR TITLE
Add Brazil (BRA3/BRA4/CB20/SPjr) and Argentina (ARY3) domestic competitions

### DIFF
--- a/tfmkt/spiders/clubs.py
+++ b/tfmkt/spiders/clubs.py
@@ -5,6 +5,20 @@ import re
 class ClubsSpider(BaseSpider):
     name = 'clubs'
 
+    def seasonize_entrypoin_href(self, item):
+        """
+        Cup-format competitions served under '/pokalwettbewerb/' (e.g. Brazil's
+        Série C/D, Sub-20, Copinha) do not expose their clubs in the league
+        'startseite' table — the '/plus/' league view is empty for them.
+        Their participating clubs live in the 'teilnehmer' (participants) view,
+        which uses the same 'club'-headed table layout this spider already
+        parses. Route those competitions to '/teilnehmer/'; defer everything
+        else to the base behaviour.
+        """
+        if item.get('type') == 'competition' and '/pokalwettbewerb/' in item['href']:
+            return f"{self.base_url}{item['href']}".replace('/startseite/', '/teilnehmer/')
+        return super().seasonize_entrypoin_href(item)
+
     def parse(self, response, parent):
         """
         Parse competition page. From this page we collect all competition's

--- a/tfmkt/spiders/competitions.py
+++ b/tfmkt/spiders/competitions.py
@@ -117,6 +117,66 @@ class CompetitionsSpider(BaseSpider):
                         'href': comp['href']
                     }
                     
+        # Add manual competitions for Brazil
+        # These are served under '/pokalwettbewerb/' (cup-format URLs), so the
+        # auto-discovery code regex (/wettbewerb/([^/]+)$) never assigns them a
+        # competition_code; they are also skipped by the tier exclusion list.
+        if base['country_id'] == '26':  # Brazil
+            manual_competitions = [
+                {
+                    'href': '/campeonato-brasileiro-serie-c/startseite/pokalwettbewerb/BRA3',
+                    'code': 'BRA3',
+                    'type': 'third_tier'
+                },
+                {
+                    'href': '/campeonato-brasileiro-serie-d/startseite/pokalwettbewerb/BRA4',
+                    'code': 'BRA4',
+                    'type': 'fourth_tier'
+                },
+                {
+                    'href': '/campeonato-brasileiro-sub-20/startseite/pokalwettbewerb/CB20',
+                    'code': 'CB20',
+                    'type': 'youth_league'
+                },
+                {
+                    'href': '/copa-sao-paulo-de-futebol-junior/startseite/pokalwettbewerb/SPjr',
+                    'code': 'SPjr',
+                    'type': 'domestic_youth_cup'
+                }
+            ]
+            for comp in manual_competitions:
+                competition_key = f"26_{comp['code']}"
+                if competition_key not in self.seen_competitions:
+                    self.seen_competitions.add(competition_key)
+                    yield {
+                        'type': 'competition',
+                        **base,
+                        'competition_code': comp['code'],
+                        'competition_type': comp['type'],
+                        'href': comp['href']
+                    }
+
+        # Add manual competitions for Argentina
+        if base['country_id'] == '9':  # Argentina
+            manual_competitions = [
+                {
+                    'href': '/torneo-proyeccion/startseite/wettbewerb/ARY3',
+                    'code': 'ARY3',
+                    'type': 'reserve_league'
+                }
+            ]
+            for comp in manual_competitions:
+                competition_key = f"9_{comp['code']}"
+                if competition_key not in self.seen_competitions:
+                    self.seen_competitions.add(competition_key)
+                    yield {
+                        'type': 'competition',
+                        **base,
+                        'competition_code': comp['code'],
+                        'competition_type': comp['type'],
+                        'href': comp['href']
+                    }
+
         # Add manual competitions for Israel
         if base['country_id'] == '74':  # Israel
             manual_competitions = [


### PR DESCRIPTION
## Summary

Adds five national/domestic competitions to the competitions discovery so they are picked up during the crawl:

| Code | Competition | Country | Type | URL format |
|------|-------------|---------|------|-----------|
| `BRA3` | Campeonato Brasileiro Série C | Brazil (26) | third_tier | `/pokalwettbewerb/` |
| `BRA4` | Campeonato Brasileiro Série D | Brazil (26) | fourth_tier | `/pokalwettbewerb/` |
| `CB20` | Campeonato Brasileiro Sub-20 | Brazil (26) | youth_league | `/pokalwettbewerb/` |
| `SPjr` | Copa São Paulo de Futebol Júnior | Brazil (26) | domestic_youth_cup | `/pokalwettbewerb/` |
| `ARY3` | Torneo Proyección | Argentina (9) | reserve_league | `/wettbewerb/` |

## Why these need manual entries

`CompetitionsSpider.parse_competitions()` doesn't auto-discover these because:
1. The auto-discovery loop **skips these tiers** (Youth league, Reserve league, Domestic Youth Cup, etc.).
2. Its code regex only matches `/wettbewerb/([^/]+)$`, so the four Brazilian comps served under `/pokalwettbewerb/` would never get a `competition_code` even if found.

They are added via per-country `manual_competitions` blocks keyed by `country_id`, following the existing Italy/England/Ireland/Israel pattern (same dict keys, same `seen_competitions` dedup guard). Domestic only — nothing was added to any international list.

## Clubs spider change

The four Brazilian comps use cup-format `/pokalwettbewerb/` URLs. Their `/startseite/.../plus/` league view lists **no clubs** — the participating clubs live in the `/teilnehmer/` (participants) view, which uses the same `club`-headed table layout the clubs spider already parses. `ClubsSpider.seasonize_entrypoin_href` is overridden to route `/pokalwettbewerb/` comps to `/teilnehmer/`. Scoped to `ClubsSpider` so the games spiders' `startseite`-based crawl is unaffected.

## Verification (live crawls)

Competitions crawl (Americas confederation) → all 5 present with non-null `competition_code`.

Clubs crawl on those 5 → each yields participating clubs:

```
BRA3=20  BRA4=96  CB20=20  SPjr=110  ARY3=28   (274 clubs, ~9,200 players)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for competitions in Brazil and Argentina with expanded competition data coverage

* **Improvements**
  * Enhanced handling of cup-format competitions for more accurate data routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->